### PR TITLE
Fix Proto Gen with Local Files

### DIFF
--- a/tools/gen_lua_proto_schema
+++ b/tools/gen_lua_proto_schema
@@ -309,10 +309,12 @@ def main():
         subprocess.check_call(
             [
                 "protoc",
-                f"--descriptor_set_out",
+                "--descriptor_set_out",
                 os.path.join(tmpdir, "descriptor.pb"),
                 "--include_imports",
-                f"--proto_path",
+                "--proto_path",
+                ".",
+                "--proto_path",
                 tmpdir,
                 input_proto_files[0],
             ]


### PR DESCRIPTION
The script to generate the lua proto schema is unable to find `.proto` files when providing local paths, regardless if absolute or relative paths are provided.

The following error is returned from the proto compiler:
> File does not reside within any path specified using --proto_path (or -I).  You must specify a --proto_path which encompasses this file.  Note that the proto_path must be an exact prefix of the .proto file names -- protoc is too dumb to figure out when two paths (e.g. absolute and relative) are equivalent (it's harder than you think).

The compiler cannot find the local proto file because the proto path provided is set to the tmp directory used for remote files. I have added the current directory as an additional proto path, which should cover most use cases. Another option is to derive a set of base directories for all input files, i.e. the `resolve_input` method could return a tuple of file path and resolved proto path (or tmpdir for remote files). Happy to make this change if you prefer.


