### PR TITLE
Fix compatibility with ESPHome 2025.10.0 passwordless devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
 [//]: # "### Removed"
 [//]: # "- Removed"
 
+## v20251031 - 2025-10-31
+
+### Fixed
+
+- Fixed compatibility with ESPHome 2025.10.0 for devices configured
+  without passwords
+- Improved password authentication failure detection and error reporting
+
 ## v20251022 - 2025-10-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -394,6 +394,14 @@ Control4, you can file an issue on GitHub:
 
 # <span style="color:#17BCF2">Changelog</span>
 
+## v20251031 - 2025-10-31
+
+### Fixed
+
+- Fixed compatibility with ESPHome 2025.10.0 for devices configured
+  without passwords
+- Improved password authentication failure detection and error reporting
+
 ## v20251022 - 2025-10-22
 
 ### Fixed


### PR DESCRIPTION
- Implemented a fatal error mechanism for async authentication failures.
- Enhanced driver status messages during password authentication.
- Removed the deprecated `_authenticated` flag and `authRequired` parameter.