### PR TITLE
Fix datetime TZ rendering and add Select option validation

### DIFF
--- a/src/esphome/entities/datetime.lua
+++ b/src/esphome/entities/datetime.lua
@@ -30,8 +30,10 @@ function DateTimeEntity:updated(entity, state)
     return
   end
 
+  -- The wire uses UTC epoch; format in the project's local time (os.date defaults to local)
+  -- so the variable round-trips with os.time on write.
   local epochSeconds = state.epoch_seconds or 0
-  local t = os.date("!*t", epochSeconds)
+  local t = os.date("*t", epochSeconds)
   local formatted = string.format("%04d-%02d-%02d %02d:%02d:%02d", t.year, t.month, t.day, t.hour, t.min, t.sec)
   values:update(entity.name, formatted, "STRING", function(newValue)
     local year, month, day, hour, minute, second = (newValue or ""):match(

--- a/src/esphome/entities/select.lua
+++ b/src/esphome/entities/select.lua
@@ -43,14 +43,34 @@ end
 --- @return void
 function SelectEntity:updated(entity, state)
   log:trace("SelectEntity:updated(%s, %s)", entity, state)
-  values:update(entity.name, state.state or "", "STRING", function(newValue)
+  local currentState = state.state or ""
+  values:update(entity.name, currentState, "STRING", function(newValue)
+    newValue = newValue or ""
+    local options = Select(selectRegistry, entity.name, "options") or {}
+    local isValid = false
+    for _, opt in ipairs(options) do
+      if opt == newValue then
+        isValid = true
+        break
+      end
+    end
+    if not isValid then
+      log:error(
+        "Invalid option '%s' for select.%s (valid: %s); reverting",
+        newValue,
+        entity.object_id,
+        table.concat(options, ", ")
+      )
+      C4:SetVariable(entity.name, currentState)
+      return
+    end
     self.client
       :callServiceMethod(ESPHomeProtoSchema.RPC.APIConnection.select_command, {
         key = entity.key,
-        state = newValue or "",
+        state = newValue,
       })
       :next(function()
-        log:info("Select option updated to '%s' for select.%s", newValue or "", entity.object_id)
+        log:info("Select option updated to '%s' for select.%s", newValue, entity.object_id)
       end, function(error)
         log:error("Failed to update select option for select.%s: %s", entity.name, error)
       end)
@@ -111,6 +131,23 @@ function EC.Set_Select(params)
   local entry = selectRegistry[selectName]
   if not entry then
     log:warn("Set Select command called for unknown select: %s", selectName)
+    return
+  end
+
+  local isValid = false
+  for _, opt in ipairs(entry.options) do
+    if opt == optionValue then
+      isValid = true
+      break
+    end
+  end
+  if not isValid then
+    log:warn(
+      "Set Select called with invalid option '%s' for '%s' (valid: %s)",
+      optionValue,
+      selectName,
+      table.concat(entry.options, ", ")
+    )
     return
   end
 

--- a/test/dummy_inputs.yaml
+++ b/test/dummy_inputs.yaml
@@ -1,0 +1,133 @@
+# Host-mode ESPHome mock exercising user-input entity types:
+#   - Select   (DRV-25)
+#   - Event    (DRV-31)
+#   - Date     (DRV-30)
+#   - Time     (DRV-30)
+#   - Datetime (DRV-30)
+#
+# Usage:
+#   esphome compile test/dummy_inputs.yaml
+#   .esphome/build/dummy-inputs/.pioenvs/dummy-inputs/program
+#
+# API services (callable from the Control4 driver or test scripts):
+#   - fire_button_press()         fires "press" on the test event
+#   - fire_button_double()        fires "double_press" on the test event
+#   - fire_button_long()          fires "long_press" on the test event
+#   - device_set_mode(opt)        changes the select option from the device side
+#   - device_set_date(y, m, d)    changes the date from the device side
+#   - device_set_time(h, m, s)    changes the time from the device side
+#   - device_set_datetime(epoch)  changes the datetime (UTC epoch) from the device side
+
+esphome:
+  name: dummy-inputs
+  friendly_name: Dummy Inputs
+
+host:
+
+logger:
+  level: DEBUG
+
+api:
+  services:
+    - service: fire_button_press
+      then:
+        - event.trigger:
+            id: test_event
+            event_type: "press"
+    - service: fire_button_double
+      then:
+        - event.trigger:
+            id: test_event
+            event_type: "double_press"
+    - service: fire_button_long
+      then:
+        - event.trigger:
+            id: test_event
+            event_type: "long_press"
+    - service: device_set_mode
+      variables:
+        opt: string
+      then:
+        - select.set:
+            id: test_mode_select
+            option: !lambda 'return opt;'
+    - service: device_set_date
+      variables:
+        y: int
+        m: int
+        d: int
+      then:
+        - datetime.date.set:
+            id: test_date
+            date: !lambda |-
+              ESPTime t{};
+              t.year = y; t.month = m; t.day_of_month = d;
+              return t;
+    - service: device_set_time
+      variables:
+        h: int
+        m: int
+        s: int
+      then:
+        - datetime.time.set:
+            id: test_time
+            time: !lambda |-
+              ESPTime t{};
+              t.hour = h; t.minute = m; t.second = s;
+              return t;
+    - service: device_set_datetime
+      variables:
+        epoch: int
+      then:
+        - datetime.datetime.set:
+            id: test_datetime
+            datetime: !lambda |-
+              return ESPTime::from_epoch_utc(static_cast<time_t>(epoch));
+
+select:
+  - platform: template
+    name: "Test Mode"
+    id: test_mode_select
+    optimistic: true
+    initial_option: "Auto"
+    restore_value: false
+    options:
+      - "Auto"
+      - "Manual"
+      - "Off"
+      - "Eco"
+
+event:
+  - platform: template
+    name: "Test Button"
+    id: test_event
+    device_class: button
+    event_types:
+      - "press"
+      - "double_press"
+      - "long_press"
+
+datetime:
+  - platform: template
+    name: "Test Date"
+    id: test_date
+    type: date
+    optimistic: true
+    initial_value: "2026-04-15"
+    restore_value: false
+
+  - platform: template
+    name: "Test Time"
+    id: test_time
+    type: time
+    optimistic: true
+    initial_value: "12:30:45"
+    restore_value: false
+
+  - platform: template
+    name: "Test Datetime"
+    id: test_datetime
+    type: datetime
+    optimistic: true
+    initial_value: "2026-04-15 09:00:00"
+    restore_value: false


### PR DESCRIPTION
## Summary

Two fixes to entity behavior introduced in the current unreleased cycle, plus a host-mode ESPHome test fixture to exercise them.

- **Datetime render in project-local time.** The wire already carries a UTC epoch, but the Lua driver was reading with ``os.date("!*t", ...)`` (UTC) and writing with ``os.time{...}`` (local). The result was a TZ-shifted round-trip (saw +5h on CDT). Dropped the ``!`` on the read side so both directions use the project's local TZ. Matches ``C4:GetTimeZone()`` and how other C4 variables present datetime values.
- **Select option validation.** Writing an unknown option to a Select variable left the stale bogus value in C4 because the device silently ignored the command. The variable write handler now validates against the entity's ``options`` list; invalid values log an error and revert the variable. The ``Set Select`` programming command does the same check.
- **``test/dummy_inputs.yaml``.** Host-mode ESPHome config exposing Select, Event, Date, Time, and Datetime entities plus API services to change each from the device side, so both directions (C4→device and device→C4) can be driven from a test harness.

## Test plan

- [x] Select: C4→device via ``Set Select`` command, device→C4 via ``device_set_mode``, invalid option via variable write, invalid option via command
- [x] Event: fire each of press / double_press / long_press from the device and confirm C4 event fires + ``Test Button Last Event`` variable tracks the latest
- [x] Date: C4→device and device→C4 round-trip, invalid format logs parse error
- [x] Time: C4→device and device→C4 round-trip, invalid format logs parse error
- [x] Datetime: C4→device in local TZ → device stores matching UTC epoch, device→C4 UTC epoch → variable displays in local TZ, invalid format logs parse error

Bidirectional tests run against ``dummy_inputs.yaml`` on a host machine in ``America/Chicago`` and an ESPHome driver instance on the controller pointing at it.