### PR TITLE
event: create Last Event variable on discovery

### DIFF
--- a/src/esphome/entities/event.lua
+++ b/src/esphome/entities/event.lua
@@ -34,6 +34,10 @@ function EventEntity:discovered(entity)
       entity.name .. " " .. eventType .. " event"
     )
   end
+
+  -- Create the Last Event variable so programming can reference it before the
+  -- first event fires. Events have no persistent state, so the initial value is empty.
+  values:update(entity.name .. " Last Event", "", "STRING")
 end
 
 --- Handle updates to the event entity state.


### PR DESCRIPTION
## Summary

DRV-31's discovery contract calls for creating the ``{name} Last Event`` variable when the event entity is discovered, in addition to registering the Control4 events for each event type. The current code only creates the variable on the first ``EventResponse``, so programming that references it immediately after a driver reload - before any button press - would fail to find the variable.

This PR adds a ``values:update(entity.name .. " Last Event", "", "STRING")`` call at the end of ``EventEntity:discovered`` so the variable is present (empty) from connect time onward. No other behavior changes.

## Test plan

Verified end-to-end against a host-mode ESPHome device with a template event entity exposing ``press`` / ``double_press`` / ``long_press``:

- [x] After ``OnDriverInit`` / connect, ``Test Button Last Event`` variable exists with value ``""``
- [x] 3 C4 events registered on discovery (one per event type)
- [x] ``fire_button_press`` / ``_double`` / ``_long`` each trigger ``[INFO]: Fired event <type> for event.test_button`` in driver output and update the Last Event variable