### PR TITLE
DRV-43: replace BT proxy hardware rec with affiliate-linked Seeed W5500

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,11 +664,13 @@ BLE devices into Control4.
 The following POE-powered Bluetooth proxies are excellent choices with 4 active
 connection slots:
 
-- [Seeed Studio XIAO ESP32C6](https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32C6-p-5884.html)
-  with POE expansion board
+- [Seeed Studio XIAO W5500 Ethernet Adapter](https://www.seeedstudio.com/XIAO-W5500-Ethernet-Adapter-p-6472.html?sensecap_affiliate=sikqXSu&referring_service=link)
 - [Olimex ESP32-POE](https://www.olimex.com/Products/IoT/ESP32/ESP32-POE/open-source-hardware)
   or
   [ESP32-POE-ISO](https://www.olimex.com/Products/IoT/ESP32/ESP32-POE-ISO/open-source-hardware)
+
+_Some hardware links above are affiliate links. Purchases through them help
+support driver development at no extra cost to you._
 
 **Firmware Installation:**
 

--- a/drivers/esphome/www/documentation/index.md
+++ b/drivers/esphome/www/documentation/index.md
@@ -760,11 +760,13 @@ BLE devices into Control4.
 The following POE-powered Bluetooth proxies are excellent choices with 4 active
 connection slots:
 
-- [Seeed Studio XIAO ESP32C6](https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32C6-p-5884.html)
-  with POE expansion board
+- [Seeed Studio XIAO W5500 Ethernet Adapter](https://www.seeedstudio.com/XIAO-W5500-Ethernet-Adapter-p-6472.html?sensecap_affiliate=sikqXSu&referring_service=link)
 - [Olimex ESP32-POE](https://www.olimex.com/Products/IoT/ESP32/ESP32-POE/open-source-hardware)
   or
   [ESP32-POE-ISO](https://www.olimex.com/Products/IoT/ESP32/ESP32-POE-ISO/open-source-hardware)
+
+_Some hardware links above are affiliate links. Purchases through them help
+support driver development at no extra cost to you._
 
 **Firmware Installation:**
 


### PR DESCRIPTION
## Summary

Replaces the standalone **XIAO ESP32C6** recommendation in the Bluetooth Proxy Configuration Guide with the **XIAO W5500 Ethernet Adapter** (paired with a XIAO ESP32S3 Plus), using Seeed's affiliate-tracked URL so purchases through the docs support driver development.

- Swap C6 → W5500, using the dashboard-generated tracking format `?sensecap_affiliate=sikqXSu&referring_service=link`
- Keep the Olimex ESP32-POE / ESP32-POE-ISO boards as a plain (non-affiliate) alternative
- Add an FTC-style affiliate disclosure under the Hardware list
- Regenerate `README.md` from the doc source to match

Only `index.md` (the source) and the generated `README.md` change. The W5500 affiliate link is the exact URL generated from the Seeed affiliate dashboard; the Olimex links stay plain since the Seeed code doesn't apply to a different vendor.

Resolves [DRV-43](https://youtrack.dmiller.me/issue/DRV-43).

## Notes

- This reaches controllers only on the next `make build` + release (docs are bundled into `esphome.c4z`); no changelog entry added since this is a docs/hardware-rec change, not a driver behavior change.