### PR TITLE
Conservative light capability baseline, enable dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
 
 ### Fixed
 
+- Declare ESPHome light hardware capabilities (dimming, color, color
+  temperature) conservatively in the static baseline and enable them at runtime
+  from the entity's discovered color modes. A full static baseline advertised
+  brightness and color for an on/off-only ESPHome light to capability consumers
+  that read the static declaration instead of the runtime-narrowed set.
 - Fixed BOOL variables (`<Entity> State` for binary_sensor and switch, plus all
   BTHome boolean sensors) staying as `False` in the Variables Agent even when
   the underlying state was changing. Variables now serialize as `"0"`/`"1"`

--- a/README.md
+++ b/README.md
@@ -880,6 +880,11 @@ can file an issue on GitHub:
 
 ### Fixed
 
+- Declare ESPHome light hardware capabilities (dimming, color, color
+  temperature) conservatively in the static baseline and enable them at runtime
+  from the entity's discovered color modes. A full static baseline advertised
+  brightness and color for an on/off-only ESPHome light to capability consumers
+  that read the static declaration instead of the runtime-narrowed set.
 - Fixed BOOL variables (`<Entity> State` for binary_sensor and switch, plus all
   BTHome boolean sensors) staying as `False` in the Variables Agent even when
   the underlying state was changing. Variables now serialize as `"0"`/`"1"`

--- a/drivers/esphome_light/driver.xml
+++ b/drivers/esphome_light/driver.xml
@@ -88,10 +88,10 @@
     <actions/>
   </config>
   <capabilities>
-    <dimmer>True</dimmer>
-    <set_level>True</set_level>
-    <supports_target>True</supports_target>
-    <supports_brightness_stop>True</supports_brightness_stop>
+    <dimmer>False</dimmer>
+    <set_level>False</set_level>
+    <supports_target>False</supports_target>
+    <supports_brightness_stop>False</supports_brightness_stop>
     <!--
       on_off, ramp_level, and supports_default_on are documented as
       "deprecated in 3.3.2" but Composer's test panel still gates UI
@@ -100,7 +100,7 @@
       the Default On preset editor including its Inactive Color picker.
     -->
     <on_off>True</on_off>
-    <ramp_level>True</ramp_level>
+    <ramp_level>False</ramp_level>
     <supports_default_on>True</supports_default_on>
     <!--
       has_fixed_ramp_rate=true means the bulb has a fixed ramp rate that
@@ -138,9 +138,9 @@
     <click_rate_max>65535</click_rate_max>
     <hold_rate_min>1000</hold_rate_min>
     <hold_rate_max>86400000</hold_rate_max>
-    <supports_color>True</supports_color>
-    <supports_color_correlated_temperature>True</supports_color_correlated_temperature>
-    <supports_color_stop>True</supports_color_stop>
+    <supports_color>False</supports_color>
+    <supports_color_correlated_temperature>False</supports_color_correlated_temperature>
+    <supports_color_stop>False</supports_color_stop>
     <color_correlated_temperature_min>2000</color_correlated_temperature_min>
     <color_correlated_temperature_max>6500</color_correlated_temperature_max>
     <color_rate_behavior>1</color_rate_behavior>


### PR DESCRIPTION
## Summary

`esphome_light`'s static `driver.xml` `<capabilities>` declared full dimming, color, and color-temperature support, and `updateDynamicCapabilities` narrowed to the entity's real `supported_color_modes` at runtime via `DYNAMIC_CAPABILITIES_CHANGED`. That works for consumers that honor the dynamic override (Composer, Navigator).

But some capability consumers read the **static** declaration rather than the runtime-narrowed set. For those, a full static baseline means an on/off-only ESPHome light (e.g. a relay configured as a light) is advertised as a dimmable color bulb.

This flips the hardware capabilities (`dimmer`, `set_level`, `supports_target`, `supports_brightness_stop`, `ramp_level`, `supports_color`, `supports_color_correlated_temperature`, `supports_color_stop`) to `False` in the static baseline. `updateDynamicCapabilities` already emits all of these from the discovered entity, so a capable light re-enables them at runtime and an on/off light stays on/off.

## Tradeoff

Composer's design-time test panel won't show brightness/color controls for a freshly added light until it connects and reports its modes. This is arguably more honest (no device, no known capabilities) and matches how the driver already behaves at runtime.

## Testing

XML validated; `make build-nodocs` passes. `updateDynamicCapabilities` logic is unchanged: a color-capable entity emits dimmer/color/CCT true; an on/off entity emits them false.