### PR TITLE
Restore dynamic bindings in OnDriverInit so connections survive Director restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 ### Fixed
 
+- Fixed Bluetooth Coordinator connections to ESPHome proxies (and other
+  dynamically created connections) disappearing after a controller reboot or
+  Director restart. Dynamic bindings are now restored early enough in driver
+  startup for Director to reconnect them.
 - Declare ESPHome light hardware capabilities (dimming, color, color
   temperature) conservatively in the static baseline and enable them at runtime
   from the entity's discovered color modes. A full static baseline advertised

--- a/README.md
+++ b/README.md
@@ -880,6 +880,10 @@ can file an issue on GitHub:
 
 ### Fixed
 
+- Fixed Bluetooth Coordinator connections to ESPHome proxies (and other
+  dynamically created connections) disappearing after a controller reboot or
+  Director restart. Dynamic bindings are now restored early enough in driver
+  startup for Director to reconnect them.
 - Declare ESPHome light hardware capabilities (dimming, color, color
   temperature) conservatively in the static baseline and enable them at runtime
   from the entity's discovered color modes. A full static baseline advertised

--- a/drivers/esphome/driver.lua
+++ b/drivers/esphome/driver.lua
@@ -130,6 +130,10 @@ function OnDriverInit()
   log:setLogLevel(Properties["Log Level"])
   log:setLogMode(Properties["Log Mode"])
   log:trace("OnDriverInit()")
+
+  -- Restore persisted state
+  values:restoreValues()
+  bindings:restoreBindings()
 end
 
 function OnDriverLateInit()
@@ -144,8 +148,6 @@ function OnDriverLateInit()
   bluetoothProxyCapability:setPropertiesAttribs(constants.HIDE_PROPERTY)
 
   C4:FileSetDir("c29tZXNwZWNpYWxrZXk=++11")
-  bindings:restoreBindings()
-  values:restoreValues()
 
   -- Fire OnPropertyChanged to set the initial Headers and other Property
   -- global sets, they'll change if Property is changed.

--- a/drivers/esphome_bluetooth_coordinator/driver.lua
+++ b/drivers/esphome_bluetooth_coordinator/driver.lua
@@ -617,6 +617,10 @@ function OnDriverInit()
   log:setLogLevel(Properties["Log Level"])
   log:setLogMode(Properties["Log Mode"])
   log:trace("OnDriverInit()")
+
+  -- Restore persisted state
+  values:restoreValues()
+  bindings:restoreBindings()
 end
 
 function OnDriverLateInit()
@@ -635,10 +639,8 @@ function OnDriverLateInit()
   log:info("Initializing Bluetooth Coordinator")
   C4:UpdateProperty("Driver Status", "Initializing...")
 
-  -- Restore persisted bindings, events, and values
-  bindings:restoreBindings()
+  -- Restore persisted events (C4:AddEvent is unavailable before OnDriverLateInit)
   events:restoreEvents()
-  values:restoreValues()
 
   -- Set up proxy bindings
   setupProxyBindings()

--- a/drivers/esphome_bthome/driver.lua
+++ b/drivers/esphome_bthome/driver.lua
@@ -765,9 +765,8 @@ function OnDriverInit()
   log:setLogMode(Properties["Log Mode"])
   log:trace("OnDriverInit()")
 
-  -- Restore all persisted values, events, and bindings
+  -- Restore persisted state
   values:restoreValues()
-  events:restoreEvents()
   bindings:restoreBindings()
 end
 
@@ -776,6 +775,9 @@ function OnDriverLateInit()
   if not CheckMinimumVersion("Driver Status") then
     return
   end
+
+  -- Restore persisted events (C4:AddEvent is unavailable before OnDriverLateInit)
+  events:restoreEvents()
 
   -- Hide all optional properties initially
   hideOptionalProperties()

--- a/drivers/esphome_climate/driver.lua
+++ b/drivers/esphome_climate/driver.lua
@@ -458,6 +458,9 @@ function OnDriverInit()
   log:setLogLevel(Properties["Log Level"])
   log:setLogMode(Properties["Log Mode"])
   log:trace("OnDriverInit()")
+
+  -- Restore persisted state
+  bindings:restoreBindings()
 end
 
 function OnDriverLateInit()
@@ -474,9 +477,6 @@ function OnDriverLateInit()
       log:error("Error in OnPropertyChanged for property '%s': %s", p, err or "unknown error")
     end
   end
-  -- Restore dynamic bindings from persistence
-  bindings:restoreBindings()
-
   -- Restore persisted state
   LAST_WATER_HEATER_MODE = persist:get("LastWaterHeaterMode")
   REMOTE_SENSOR_IN_USE = persist:get("RemoteSensorInUse") or false

--- a/drivers/esphome_govee/driver.lua
+++ b/drivers/esphome_govee/driver.lua
@@ -510,7 +510,6 @@ function OnDriverInit()
 
   -- Restore persisted state
   values:restoreValues()
-  events:restoreEvents()
   bindings:restoreBindings()
 end
 
@@ -519,6 +518,9 @@ function OnDriverLateInit()
   if not CheckMinimumVersion("Driver Status") then
     return
   end
+
+  -- Restore persisted events (C4:AddEvent is unavailable before OnDriverLateInit)
+  events:restoreEvents()
 
   -- Hide all optional properties initially
   hideOptionalProperties()

--- a/drivers/esphome_switchbot/driver.lua
+++ b/drivers/esphome_switchbot/driver.lua
@@ -1883,7 +1883,6 @@ function OnDriverInit()
 
   -- Restore persisted state
   values:restoreValues()
-  events:restoreEvents()
   bindings:restoreBindings()
 end
 
@@ -1892,6 +1891,9 @@ function OnDriverLateInit()
   if not CheckMinimumVersion("Driver Status") then
     return
   end
+
+  -- Restore persisted events (C4:AddEvent is unavailable before OnDriverLateInit)
+  events:restoreEvents()
 
   -- Hide all optional properties initially
   hideOptionalProperties()

--- a/drivers/esphome_yale/driver.lua
+++ b/drivers/esphome_yale/driver.lua
@@ -1199,6 +1199,10 @@ function OnDriverInit()
   log:setLogLevel(Properties["Log Level"])
   log:setLogMode(Properties["Log Mode"])
   log:trace("OnDriverInit()")
+
+  -- Restore persisted state
+  values:restoreValues()
+  bindings:restoreBindings()
 end
 
 function OnDriverLateInit()
@@ -1206,9 +1210,6 @@ function OnDriverLateInit()
   if not CheckMinimumVersion("Driver Status") then
     return
   end
-
-  bindings:restoreBindings()
-  values:restoreValues()
 
   for p, _ in pairs(Properties) do
     local status, err = pcall(OnPropertyChanged, p)

--- a/src/lib/bindings.lua
+++ b/src/lib/bindings.lua
@@ -199,6 +199,12 @@ end
 
 --- Restores all dynamic bindings from persistent storage. Ensures that all
 --- bindings are re-added and removes unknown bindings within managed ranges.
+---
+--- Call this from OnDriverInit, not OnDriverLateInit: Director resolves stored
+--- connections before OnDriverLateInit, and connections where this driver's
+--- binding is the consumer side are permanently dropped if the binding does
+--- not exist yet (provider-side bindings get re-attached whenever they are
+--- added, so only early restore covers both directions).
 function Bindings:restoreBindings()
   log:trace("Binding:restoreBindings()")
   local deviceBindings = GetDeviceBindings(tointeger(C4:GetDeviceID()))

--- a/src/lib/events.lua
+++ b/src/lib/events.lua
@@ -101,6 +101,8 @@ function Events:deleteEvent(namespace, key)
 end
 
 --- Restores all events from persistent storage. Ensures that all events are re-added and removes unknown events.
+---
+--- Call this from OnDriverLateInit: C4:AddEvent is unavailable earlier.
 function Events:restoreEvents()
   log:trace("Events:restoreEvents()")
   --- @type table<number, boolean>

--- a/src/lib/values.lua
+++ b/src/lib/values.lua
@@ -243,6 +243,9 @@ end
 --- values are re-added in a consistent order based on their index.
 --- Deleted values are restored as hidden placeholders to preserve
 --- variable ID ordering for subsequent variables.
+---
+--- Call this from OnDriverInit: programming attached to variables added
+--- after OnDriverInit may not work after a Director restart.
 --- @return void
 function Values:restoreValues()
   log:trace("Values:restoreValues()")


### PR DESCRIPTION
## Problem

Connections to the Bluetooth Coordinator input on ESPHome proxies disappeared after controller reboots / Director restarts (observed repeatedly on a production system; its project DB contained six stale generations of the lost connection rows, one per past rebind/loss cycle).

## Root cause

Director stores a connection as a child of the **provider's** binding row (`bound_consumers.parent_id -> bindings.id` in `project.db`) and never persists consumer-side dynamic bindings. At startup, Director resolves stored connections **before `OnDriverLateInit`**:

- Provider-side dynamic bindings self-heal: `AddDynamicBinding` on a provider re-scans and re-attaches its stored consumers at any time.
- Consumer-side dynamic bindings have no re-attach hook. If the consumer binding does not exist when the resolution pass runs, the connection is silently and permanently dropped.

Our drivers restored dynamic bindings in `OnDriverLateInit`, which is after resolution, so the coordinator connection (the only consumer-side dynamic binding in the ecosystem) was lost on **every** Director restart. Reproduced 1-for-1 on a test controller.

This matches the DriverWorks docs: the `AddDynamicBinding` restore example runs at script load, `PersistGetValue` is documented usable before LateInit, and the safe-usage table notes variables must be added in `OnDriverInit` while `AddEvent` must wait for `OnDriverLateInit`.

## Changes

- Restore dynamic bindings and variables in `OnDriverInit` in all drivers (esphome, coordinator, climate, yale; govee/bthome/switchbot already did this).
- Move event restore from `OnDriverInit` to `OnDriverLateInit` in govee/bthome/switchbot (`C4:AddEvent` is unavailable earlier; opposite violation of the same lifecycle table).
- Document the lifecycle constraints on `restoreBindings()`, `restoreValues()`, and `restoreEvents()` in the lib so callsites can stay one-line.

## Validation (test controller)

- Baseline (previous code): coordinator connections to 2 proxies dropped on the first Director restart.
- With the fix: connections to 3 proxies, including one with a device ID **above** the coordinator's (worst-case load order), survived 5 Director restarts (3 with an instrumented build, 2 with this exact build).
- Provider-side connections (lights/fans/relays/BT child devices) unaffected throughout.

## Follow-ups (separate PRs)

- Guard the `restoreBindings()` prune when persist reads empty.
- Register coordinator-binding RFP/OBC handlers at init instead of on capability discovery.
- Coordinator: accept `PROXY_CONNECTED` from unknown-but-bound proxies.

After updating, any previously lost connections need one manual rebind; they will persist from then on. The same latent bug exists in control4-tplink and control4-home-connect.