### PR TITLE
Fix state updates dropped for ESPHome firmware that omits object_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ### Fixed
 
+- Fixed all entity states appearing frozen in Control4 (covers stuck on
+  "Unknown", sensor variables never updating) on ESPHome 2026.7+ firmware, which
+  no longer sends the deprecated `object_id` field. The driver no longer reads
+  `object_id`, and log messages now identify entities as `type 'Name' (key=N)`.
 - Bumped the ESPHome native API version advertised in `HelloRequest` from 1.0 to
   1.14 so devices no longer log `using outdated API 1.0, update to 1.14+` on
   every connection.

--- a/README.md
+++ b/README.md
@@ -910,6 +910,10 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ### Fixed
 
+- Fixed all entity states appearing frozen in Control4 (covers stuck on
+  "Unknown", sensor variables never updating) on ESPHome 2026.7+ firmware, which
+  no longer sends the deprecated `object_id` field. The driver no longer reads
+  `object_id`, and log messages now identify entities as `type 'Name' (key=N)`.
 - Bumped the ESPHome native API version advertised in `HelloRequest` from 1.0 to
   1.14 so devices no longer log `using outdated API 1.0, update to 1.14+` on
   every connection.

--- a/drivers/esphome/driver.lua
+++ b/drivers/esphome/driver.lua
@@ -521,7 +521,7 @@ function RefreshStatus()
         log:debug("Device Info: %s", deviceInfo)
         -- First successful operation confirms authentication succeeded
         updateStatus("Connected")
-        values:update("Name", Select(deviceInfo, "friendly_name") or Select(deviceInfo, "name") or "N/A", "STRING")
+        values:update("Name", esphome:getDeviceName() or "N/A", "STRING")
         values:update("Model", Select(deviceInfo, "model") or "N/A", "STRING")
         values:update("Manufacturer", Select(deviceInfo, "manufacturer") or "N/A", "STRING")
         values:update("MAC Address", Select(deviceInfo, "mac_address") or "N/A", "STRING")
@@ -552,9 +552,9 @@ function RefreshStatus()
 
           -- Detect restart button for scanner recovery
           if entity.entity_type == "button" then
-            local objectId = entity.object_id or ""
-            if objectId:lower():find("restart") then
-              log:info("Found restart button entity: %s (key=%s)", objectId, entity.key)
+            local buttonName = entity.name or ""
+            if buttonName:lower():find("restart") then
+              log:info("Found restart button entity: %s", ESPHomeClient.describeEntity(entity))
               bluetoothProxyCapability:setRestartButtonKey(entity.key)
             end
           end
@@ -575,7 +575,7 @@ function RefreshStatus()
           end
 
           local entity = Select(entities, tostring(key))
-          if IsEmpty(Select(entity, "entity_type")) or IsEmpty(Select(entity, "object_id")) then
+          if IsEmpty(Select(entity, "entity_type")) then
             log:warn("Received state update for unknown entity with key %s", state.key)
             return
           end
@@ -583,7 +583,7 @@ function RefreshStatus()
 
           state.key = nil -- Just remove this as its no longer needed
 
-          log:info("State update for %s.%s entity -> %s", entity.entity_type, entity.object_id, state)
+          log:info("State update for %s entity -> %s", ESPHomeClient.describeEntity(entity), state)
 
           if Entities[entity.entity_type] ~= nil and type(Entities[entity.entity_type].updated) == "function" then
             log:debug("Calling Entities['%s']:updated(%s, %s) handler", entity.entity_type, entity, state)

--- a/src/esphome/client.lua
+++ b/src/esphome/client.lua
@@ -100,6 +100,20 @@ ESPHomeClient.EntityType = {
   WATER_HEATER = "water_heater",
 }
 
+--- Human-readable entity identity for log messages: `type 'Name' (key=N)`.
+--- Names are display strings (spaces, capitalization, possible duplicates), so
+--- the key is included to keep log lines unambiguous.
+--- @param entity table<string, any> The entity data received from the ESPHome client.
+--- @return string identity The formatted entity identity.
+function ESPHomeClient.describeEntity(entity)
+  return string.format(
+    "%s '%s' (key=%s)",
+    Select(entity, "entity_type") or "entity",
+    Select(entity, "name") or "",
+    Select(entity, "key") or "?"
+  )
+end
+
 --- @class BluetoothConnectionState
 --- @field free number Number of available connection slots
 --- @field limit number Maximum number of connection slots
@@ -438,7 +452,25 @@ end
 --- @return Deferred<ProtoDeviceInfoResponse, string> result A promise that resolves with the device information.
 function ESPHomeClient:getDeviceInfo()
   log:trace("ESPHomeClient:getDeviceInfo()")
-  return self:callServiceMethod(ESPHomeProtoSchema.RPC.APIConnection.device_info, {})
+  return self:callServiceMethod(ESPHomeProtoSchema.RPC.APIConnection.device_info, {}):next(function(deviceInfo)
+    self._deviceInfo = deviceInfo
+    return deviceInfo
+  end)
+end
+
+--- The device's display name from the most recent device info response.
+--- @return string|nil name The friendly name, or nil if not yet known.
+function ESPHomeClient:getDeviceName()
+  -- Unset proto string fields decode as "" (truthy in Lua), so fall back with
+  -- IsEmpty rather than `or`.
+  local name = Select(self._deviceInfo, "friendly_name")
+  if IsEmpty(name) then
+    name = Select(self._deviceInfo, "name")
+  end
+  if IsEmpty(name) then
+    return nil
+  end
+  return name
 end
 
 --- Press a button entity by its key.

--- a/src/esphome/entities/button.lua
+++ b/src/esphome/entities/button.lua
@@ -43,9 +43,9 @@ function ButtonEntity:discovered(entity)
       self.client
         :callServiceMethod(ESPHomeProtoSchema.RPC.APIConnection.button_command, { key = entity.key })
         :next(function()
-          log:debug("Command press sent to %s.%s", entity.entity_type, entity.object_id)
+          log:debug("Command press sent to %s", ESPHomeClient.describeEntity(entity))
         end, function(error)
-          log:error("An error occurred sending command press to %s.%s; %s", entity.entity_type, entity.object_id, error)
+          log:error("An error occurred sending command press to %s; %s", ESPHomeClient.describeEntity(entity), error)
         end)
     end
   end

--- a/src/esphome/entities/climate.lua
+++ b/src/esphome/entities/climate.lua
@@ -25,14 +25,12 @@ function ClimateEntity:discovered(entity)
   log:trace("ClimateEntity:discovered(%s)", entity)
   local displayName = entity.name
   if IsEmpty(displayName) then
-    if not IsEmpty(entity.object_id) then
-      -- Convert snake_case object_id to Title Case (e.g. "water_heater" -> "Water Heater")
-      displayName = entity.object_id:gsub("_", " "):gsub("(%a)([%w]*)", function(first, rest)
-        return first:upper() .. rest
-      end)
-    else
-      displayName = (entity.entity_type or "climate"):gsub("^%l", string.upper) .. " " .. entity.key
-    end
+    -- An empty name marks the device's main entity; show it under the device
+    -- name, the way Home Assistant does.
+    displayName = self.client:getDeviceName()
+  end
+  if IsEmpty(displayName) then
+    displayName = (entity.entity_type or "climate"):gsub("^%l", string.upper) .. " " .. entity.key
   end
   local bindingId = assert(
     bindings:getOrAddDynamicBinding(self.TYPE, "climate_" .. entity.key, "PROXY", true, displayName, "ESPHOME_CLIMATE")
@@ -58,21 +56,19 @@ function ClimateEntity:discovered(entity)
       body.key = body.key or entity.key
       self.client:callServiceMethod(command, body):next(function()
         log:debug(
-          "Method %s.%s(%s) called by entity %s.%s",
+          "Method %s.%s(%s) called by entity %s",
           command.service,
           command.method,
           body,
-          entity.entity_type,
-          entity.object_id
+          ESPHomeClient.describeEntity(entity)
         )
       end, function(error)
         log:error(
-          "An error occurred calling method %s.%s(%s) by entity %s.%s; %s",
+          "An error occurred calling method %s.%s(%s) by entity %s; %s",
           command.service,
           command.method,
           body,
-          entity.entity_type,
-          entity.object_id,
+          ESPHomeClient.describeEntity(entity),
           error
         )
       end)

--- a/src/esphome/entities/cover.lua
+++ b/src/esphome/entities/cover.lua
@@ -101,7 +101,7 @@ function CoverEntity:discovered(entity)
         stopCommand = true
         coverCommand = "stop"
       else
-        log:warn("Unknown binding id %s for %s.%s", idBinding, entity.entity_type, entity.object_id)
+        log:warn("Unknown binding id %s for %s", idBinding, ESPHomeClient.describeEntity(entity))
         return
       end
     else
@@ -115,7 +115,7 @@ function CoverEntity:discovered(entity)
         legacyCommand = ESPHomeProtoSchema.Enum.LegacyCoverCommand.LEGACY_COVER_COMMAND_STOP
         coverCommand = "stop"
       else
-        log:warn("Unknown binding id %s for %s.%s", idBinding, entity.entity_type, entity.object_id)
+        log:warn("Unknown binding id %s for %s", idBinding, ESPHomeClient.describeEntity(entity))
         return
       end
     end
@@ -133,13 +133,12 @@ function CoverEntity:discovered(entity)
           stop = stopCommand,
         })
         :next(function()
-          log:debug("Command %s sent to %s.%s", coverCommand, entity.entity_type, entity.object_id)
+          log:debug("Command %s sent to %s", coverCommand, ESPHomeClient.describeEntity(entity))
         end, function(error)
           log:error(
-            "An error occurred sending command %s to %s.%s; %s",
+            "An error occurred sending command %s to %s; %s",
             coverCommand,
-            entity.entity_type,
-            entity.object_id,
+            ESPHomeClient.describeEntity(entity),
             error
           )
         end)

--- a/src/esphome/entities/date.lua
+++ b/src/esphome/entities/date.lua
@@ -35,9 +35,8 @@ function DateEntity:updated(entity, state)
     local year, month, day = (newValue or ""):match("^(%d%d%d%d)-(%d%d)-(%d%d)$")
     if not year then
       log:error(
-        "Invalid date format for %s.%s: %s (expected YYYY-MM-DD)",
-        entity.entity_type,
-        entity.object_id,
+        "Invalid date format for %s: %s (expected YYYY-MM-DD)",
+        ESPHomeClient.describeEntity(entity),
         newValue or ""
       )
       return
@@ -50,9 +49,9 @@ function DateEntity:updated(entity, state)
         day = tonumber(day),
       })
       :next(function()
-        log:info("Date updated to %s for %s.%s", newValue, entity.entity_type, entity.object_id)
+        log:info("Date updated to %s for %s", newValue, ESPHomeClient.describeEntity(entity))
       end, function(error)
-        log:error("Failed to update date for %s.%s: %s", entity.entity_type, entity.object_id, error)
+        log:error("Failed to update date for %s: %s", ESPHomeClient.describeEntity(entity), error)
       end)
   end)
 end

--- a/src/esphome/entities/datetime.lua
+++ b/src/esphome/entities/datetime.lua
@@ -41,9 +41,8 @@ function DateTimeEntity:updated(entity, state)
     )
     if not year then
       log:error(
-        "Invalid datetime format for %s.%s: %s (expected YYYY-MM-DD HH:MM:SS)",
-        entity.entity_type,
-        entity.object_id,
+        "Invalid datetime format for %s: %s (expected YYYY-MM-DD HH:MM:SS)",
+        ESPHomeClient.describeEntity(entity),
         newValue or ""
       )
       return
@@ -62,9 +61,9 @@ function DateTimeEntity:updated(entity, state)
         epoch_seconds = epoch,
       })
       :next(function()
-        log:info("Datetime updated to %s for %s.%s", newValue, entity.entity_type, entity.object_id)
+        log:info("Datetime updated to %s for %s", newValue, ESPHomeClient.describeEntity(entity))
       end, function(error)
-        log:error("Failed to update datetime for %s.%s: %s", entity.entity_type, entity.object_id, error)
+        log:error("Failed to update datetime for %s: %s", ESPHomeClient.describeEntity(entity), error)
       end)
   end)
 end

--- a/src/esphome/entities/event.lua
+++ b/src/esphome/entities/event.lua
@@ -49,7 +49,7 @@ function EventEntity:updated(entity, state)
 
   local eventType = state.event_type or ""
   if IsEmpty(eventType) then
-    log:warn("Received event with empty event_type for %s.%s", entity.entity_type, entity.object_id)
+    log:warn("Received event with empty event_type for %s", ESPHomeClient.describeEntity(entity))
     return
   end
 
@@ -58,7 +58,7 @@ function EventEntity:updated(entity, state)
 
   -- Fire the corresponding C4 event
   events:fire("event_" .. entity.key, eventType)
-  log:info("Fired event %s for %s.%s", eventType, entity.entity_type, entity.object_id)
+  log:info("Fired event %s for %s", eventType, ESPHomeClient.describeEntity(entity))
 end
 
 return EventEntity

--- a/src/esphome/entities/fan.lua
+++ b/src/esphome/entities/fan.lua
@@ -45,21 +45,19 @@ function FanEntity:discovered(entity)
       body.key = body.key or entity.key
       self.client:callServiceMethod(command, body):next(function()
         log:debug(
-          "Method %s.%s(%s) called by entity %s.%s",
+          "Method %s.%s(%s) called by entity %s",
           command.service,
           command.method,
           body,
-          entity.entity_type,
-          entity.object_id
+          ESPHomeClient.describeEntity(entity)
         )
       end, function(error)
         log:error(
-          "An error occurred calling method %s.%s(%s) by entity %s.%s; %s",
+          "An error occurred calling method %s.%s(%s) by entity %s; %s",
           command.service,
           command.method,
           body,
-          entity.entity_type,
-          entity.object_id,
+          ESPHomeClient.describeEntity(entity),
           error
         )
       end)

--- a/src/esphome/entities/light.lua
+++ b/src/esphome/entities/light.lua
@@ -38,21 +38,19 @@ function LightEntity:discovered(entity)
       body.key = body.key or entity.key
       self.client:callServiceMethod(command, body):next(function()
         log:debug(
-          "Method %s.%s(%s) called by entity %s.%s",
+          "Method %s.%s(%s) called by entity %s",
           command.service,
           command.method,
           body,
-          entity.entity_type,
-          entity.object_id
+          ESPHomeClient.describeEntity(entity)
         )
       end, function(error)
         log:error(
-          "An error occurred calling method %s.%s(%s) by entity %s.%s; %s",
+          "An error occurred calling method %s.%s(%s) by entity %s; %s",
           command.service,
           command.method,
           body,
-          entity.entity_type,
-          entity.object_id,
+          ESPHomeClient.describeEntity(entity),
           error
         )
       end)

--- a/src/esphome/entities/lock.lua
+++ b/src/esphome/entities/lock.lua
@@ -38,21 +38,19 @@ function LockEntity:discovered(entity)
       body.key = body.key or entity.key
       self.client:callServiceMethod(command, body):next(function()
         log:debug(
-          "Method %s.%s(%s) called by entity %s.%s",
+          "Method %s.%s(%s) called by entity %s",
           command.service,
           command.method,
           body,
-          entity.entity_type,
-          entity.object_id
+          ESPHomeClient.describeEntity(entity)
         )
       end, function(error)
         log:error(
-          "An error occurred calling method %s.%s(%s) by entity %s.%s; %s",
+          "An error occurred calling method %s.%s(%s) by entity %s; %s",
           command.service,
           command.method,
           body,
-          entity.entity_type,
-          entity.object_id,
+          ESPHomeClient.describeEntity(entity),
           error
         )
       end)

--- a/src/esphome/entities/number.lua
+++ b/src/esphome/entities/number.lua
@@ -33,9 +33,9 @@ function NumberEntity:updated(entity, state)
         state = numValue,
       })
       :next(function()
-        log:info("Number value updated to %s for %s.%s", numValue, entity.entity_type, entity.object_id)
+        log:info("Number value updated to %s for %s", numValue, ESPHomeClient.describeEntity(entity))
       end, function(error)
-        log:error("Failed to update number value for %s.%s: %s", entity.entity_type, entity.object_id, error)
+        log:error("Failed to update number value for %s: %s", ESPHomeClient.describeEntity(entity), error)
       end)
   end)
 end

--- a/src/esphome/entities/select.lua
+++ b/src/esphome/entities/select.lua
@@ -56,9 +56,9 @@ function SelectEntity:updated(entity, state)
     end
     if not isValid then
       log:error(
-        "Invalid option '%s' for select.%s (valid: %s); reverting",
+        "Invalid option '%s' for %s (valid: %s); reverting",
         newValue,
-        entity.object_id,
+        ESPHomeClient.describeEntity(entity),
         table.concat(options, ", ")
       )
       C4:SetVariable(entity.name, currentState)
@@ -70,9 +70,9 @@ function SelectEntity:updated(entity, state)
         state = newValue,
       })
       :next(function()
-        log:info("Select option updated to '%s' for select.%s", newValue, entity.object_id)
+        log:info("Select option updated to '%s' for %s", newValue, ESPHomeClient.describeEntity(entity))
       end, function(error)
-        log:error("Failed to update select option for select.%s: %s", entity.name, error)
+        log:error("Failed to update select option for %s: %s", ESPHomeClient.describeEntity(entity), error)
       end)
   end)
 end

--- a/src/esphome/entities/switch.lua
+++ b/src/esphome/entities/switch.lua
@@ -50,28 +50,27 @@ function SwitchEntity:discovered(entity)
         state = state,
       })
       :next(function()
-        log:debug("Command %s sent to %s.%s", state and "on" or "off", entity.entity_type, entity.object_id)
+        log:debug("Command %s sent to %s", state and "on" or "off", ESPHomeClient.describeEntity(entity))
       end, function(error)
         log:error(
-          "An error occurred sending command %s to %s.%s; %s",
+          "An error occurred sending command %s to %s; %s",
           state and "on" or "off",
-          entity.entity_type,
-          entity.object_id,
+          ESPHomeClient.describeEntity(entity),
           error
         )
       end)
     if pulseTime > 0 then
       SetTimer("FinishPulse", pulseTime, function()
-        log:debug("Turning off %s.%s after pulse time of %dms", entity.entity_type, entity.object_id, pulseTime)
+        log:debug("Turning off %s after pulse time of %dms", ESPHomeClient.describeEntity(entity), pulseTime)
         self.client
           :callServiceMethod(ESPHomeProtoSchema.RPC.APIConnection.switch_command, {
             key = entity.key,
             state = false,
           })
           :next(function()
-            log:debug("Command off sent to %s.%s", entity.entity_type, entity.object_id)
+            log:debug("Command off sent to %s", ESPHomeClient.describeEntity(entity))
           end, function(error)
-            log:error("An error occurred sending command off to %s.%s; %s", entity.entity_type, entity.object_id, error)
+            log:error("An error occurred sending command off to %s; %s", ESPHomeClient.describeEntity(entity), error)
           end)
       end)
     end
@@ -96,12 +95,11 @@ function SwitchEntity:updated(entity, state)
         state = boolValue,
       })
       :next(function()
-        log:info("Commanded %s.%s to %s", entity.entity_type, entity.object_id, boolValue and "on" or "off")
+        log:info("Commanded %s to %s", ESPHomeClient.describeEntity(entity), boolValue and "on" or "off")
       end, function(error)
         log:error(
-          "Failed to command %s.%s to %s: %s",
-          entity.entity_type,
-          entity.object_id,
+          "Failed to command %s to %s: %s",
+          ESPHomeClient.describeEntity(entity),
           boolValue and "on" or "off",
           error
         )

--- a/src/esphome/entities/text.lua
+++ b/src/esphome/entities/text.lua
@@ -32,9 +32,9 @@ function TextEntity:updated(entity, state)
         state = newValue or "",
       })
       :next(function()
-        log:info("Text value updated to %s for text.%s", newValue or "", entity.object_id)
+        log:info("Text value updated to %s for %s", newValue or "", ESPHomeClient.describeEntity(entity))
       end, function(error)
-        log:error("Failed to update text value for number.%s: %s", entity.name, error)
+        log:error("Failed to update text value for %s: %s", ESPHomeClient.describeEntity(entity), error)
       end)
   end)
 end

--- a/src/esphome/entities/time.lua
+++ b/src/esphome/entities/time.lua
@@ -35,9 +35,8 @@ function TimeEntity:updated(entity, state)
     local hour, minute, second = (newValue or ""):match("^(%d%d):(%d%d):(%d%d)$")
     if not hour then
       log:error(
-        "Invalid time format for %s.%s: %s (expected HH:MM:SS)",
-        entity.entity_type,
-        entity.object_id,
+        "Invalid time format for %s: %s (expected HH:MM:SS)",
+        ESPHomeClient.describeEntity(entity),
         newValue or ""
       )
       return
@@ -50,9 +49,9 @@ function TimeEntity:updated(entity, state)
         second = tonumber(second),
       })
       :next(function()
-        log:info("Time updated to %s for %s.%s", newValue, entity.entity_type, entity.object_id)
+        log:info("Time updated to %s for %s", newValue, ESPHomeClient.describeEntity(entity))
       end, function(error)
-        log:error("Failed to update time for %s.%s: %s", entity.entity_type, entity.object_id, error)
+        log:error("Failed to update time for %s: %s", ESPHomeClient.describeEntity(entity), error)
       end)
   end)
 end

--- a/src/esphome/entities/water_heater.lua
+++ b/src/esphome/entities/water_heater.lua
@@ -35,13 +35,12 @@ function WaterHeaterEntity:discovered(entity)
   entity.is_water_heater = true
   local displayName = entity.name
   if IsEmpty(displayName) then
-    if not IsEmpty(entity.object_id) then
-      displayName = entity.object_id:gsub("_", " "):gsub("(%a)([%w]*)", function(first, rest)
-        return first:upper() .. rest
-      end)
-    else
-      displayName = "Water Heater " .. entity.key
-    end
+    -- An empty name marks the device's main entity; show it under the device
+    -- name, the way Home Assistant does.
+    displayName = self.client:getDeviceName()
+  end
+  if IsEmpty(displayName) then
+    displayName = "Water Heater " .. entity.key
   end
   local bindingId = assert(
     bindings:getOrAddDynamicBinding(
@@ -74,21 +73,19 @@ function WaterHeaterEntity:discovered(entity)
       body.key = body.key or entity.key
       self.client:callServiceMethod(command, body):next(function()
         log:debug(
-          "Method %s.%s(%s) called by entity %s.%s",
+          "Method %s.%s(%s) called by entity %s",
           command.service,
           command.method,
           body,
-          entity.entity_type,
-          entity.object_id
+          ESPHomeClient.describeEntity(entity)
         )
       end, function(error)
         log:error(
-          "An error occurred calling method %s.%s(%s) by entity %s.%s; %s",
+          "An error occurred calling method %s.%s(%s) by entity %s; %s",
           command.service,
           command.method,
           body,
-          entity.entity_type,
-          entity.object_id,
+          ESPHomeClient.describeEntity(entity),
           error
         )
       end)
@@ -128,7 +125,7 @@ function WaterHeaterEntity:updated(entity, state, messageSchema)
   -- overwrites the climate entity during discovery (same key), ClimateStateResponse
   -- will route here with stale data. Ignore it.
   if messageSchema and messageSchema.name ~= "WaterHeaterStateResponse" then
-    log:debug("Ignoring %s for water heater entity %s", messageSchema.name, entity.object_id)
+    log:debug("Ignoring %s for %s", messageSchema.name, ESPHomeClient.describeEntity(entity))
     return
   end
   -- Translate WaterHeaterMode to ClimateMode + custom_preset


### PR DESCRIPTION
Newer ESPHome firmware (observed with **2026.7.2**) no longer sends the deprecated `object_id` field in list entities responses. The state dispatch guard required it, so every state update was dropped as `Received state update for unknown entity` while the connection looked healthy — covers stuck on **"Unknown"**, sensor variables never created. Devices on older firmware still send the field and were unaffected.

## Fix — remove the `object_id` dependency entirely

- State dispatch requires only `entity_type`; entity identity is the numeric key, as it always was.
- Restart-button detection matches the entity **name** — same selectivity, since `object_id` was derived from the name (`device_class` can't be used: both *Restart* and *Safe mode boot* carry `"restart"`).
- All entity log sites use a shared `ESPHomeClient.describeEntity` helper producing `type 'Name' (key=N)` — display names read cleanly and duplicate names stay distinguishable by key.
- Empty-named climate/water-heater entities take the **device name** for their sub-driver display name (Home Assistant semantics for a device's main entity) instead of reconstructing it from `object_id`; the client now caches device info and exposes `getDeviceName()`, which `RefreshStatus` also uses for the `Name` value. Fallbacks use `IsEmpty` rather than `or`, since unset proto string fields decode as `""` (truthy in Lua).
- Fixes a pre-existing copy-paste typo in `text.lua`'s failure log (`number.%s`).

After this, no code path reads `object_id` — it survives only as wire-schema passthrough and a name-first fallback in one test utility. Behavior is identical on firmware that still sends the field.

## Verification

- **Live on production:** both affected ratgdo32 devices (2026.7.2) recovered the full entity set on the first refresh after deploy; the bound garage-door proxy went from `STATE = "Unknown"` to the correct state with no door movement; states render as `State update for sensor 'Temperature' (key=899752953) -> {"state":32.5}`; name-based restart detection picks the correct button; an unaffected 2026.3.1 device verified for regression.
- Every `log:*` call's format-specifier/argument arity audited programmatically — all match.
- `luajit` syntax checks pass; stylua/mdformat idempotent; `make preprocess gen-squishy update-xml package` exits 0; generated CHANGELOG/README formatting committed.
- The empty-name display path is not exercisable on the test devices (all entities named) — verified statically only.

## Notes

- Trivial CHANGELOG conflict with #70 (both touch `Unreleased`).
- The latent bug found during this investigation — `disconnect()` clears the callback registry without rejecting in-flight deferreds, silently stalling any awaiting chain — is tracked as **DRV-55**.