### PR TITLE
Re-notify bound consumers after a driver restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ### Fixed
 
+- Fixed cover contacts, Yale DoorSense, BTHome bindings, and the SwitchBot Bot
+  relay leaving bound consumers stale after a driver restart or update until the
+  next state change
 - Fixed all entity states appearing frozen in Control4 (covers stuck on
   "Unknown", sensor variables never updating) on ESPHome 2026.7+ firmware, which
   no longer sends the deprecated `object_id` field. The driver no longer reads

--- a/README.md
+++ b/README.md
@@ -917,6 +917,9 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ### Fixed
 
+- Fixed cover contacts, Yale DoorSense, BTHome bindings, and the SwitchBot Bot
+  relay leaving bound consumers stale after a driver restart or update until the
+  next state change
 - Fixed all entity states appearing frozen in Control4 (covers stuck on
   "Unknown", sensor variables never updating) on ESPHome 2026.7+ firmware, which
   no longer sends the deprecated `object_id` field. The driver no longer reads

--- a/drivers/esphome_bthome/driver.lua
+++ b/drivers/esphome_bthome/driver.lua
@@ -620,6 +620,12 @@ end
 -- Data Processing
 --------------------------------------------------------------------------------
 
+--- Last value notified per variable this session. In-memory on purpose: a
+--- driver restart clears it, so bound consumers are re-notified even when the
+--- value matches the persisted variable.
+--- @type table<string, any>
+local lastNotified = {}
+
 --- Process a BTHome object and update the corresponding variable/property
 --- @param reading BTHomeReading The BTHome object with value, unit, event fields
 --- @param summaryParts string[] Table to append summary parts to
@@ -695,7 +701,7 @@ local function processBTHomeReading(reading, summaryParts)
   end
 
   -- Update the variable (and property if applicable via suffix)
-  local changed = values:update(varName, displayValue, varDef.type, nil, reading.unit and (" " .. reading.unit) or nil)
+  values:update(varName, displayValue, varDef.type, nil, reading.unit and (" " .. reading.unit) or nil)
 
   -- Add to summary
   local unit = reading.unit and (" " .. reading.unit) or ""
@@ -706,10 +712,12 @@ local function processBTHomeReading(reading, summaryParts)
     values:update("Temperature F", c2f(value), varDef.type, nil, " °F")
   end
 
-  -- Only send to bindings if value changed
-  if not changed then
+  -- Only send to bindings when the value changed this session. Deduped in
+  -- memory so a driver restart re-notifies bound consumers.
+  if lastNotified[varName] == displayValue then
     return
   end
+  lastNotified[varName] = displayValue
 
   -- Send to sensor binding if applicable
   local sensorConfig = SENSOR_BINDINGS[reading.name]

--- a/drivers/esphome_switchbot/driver.lua
+++ b/drivers/esphome_switchbot/driver.lua
@@ -515,12 +515,19 @@ local function isBotSwitchMode()
   return Select(values:getValue("Mode"), "value") == "Switch"
 end
 
+--- Last Bot state notified this session. In-memory on purpose: a driver
+--- restart clears it, so the bound consumer is re-notified.
+--- @type boolean|nil
+local lastNotifiedBotState = nil
+
 --- Set the Bot state and notify bound consumers
 --- @param isOn boolean Whether the Bot is on
 local function setBotState(isOn)
   log:trace("setBotState(%s)", isOn)
-  local changed = values:update("State", isOn and "On" or "Off", "STRING")
-  if changed then
+  values:update("State", isOn and "On" or "Off", "STRING")
+  -- Deduped in memory so a driver restart re-notifies the bound consumer.
+  if lastNotifiedBotState ~= isOn then
+    lastNotifiedBotState = isOn
     local binding = bindings:getDynamicBinding(BINDINGS_NAMESPACE, "botRelay")
     if binding then
       SendToProxy(binding.bindingId, isOn and "CLOSED" or "OPENED", {}, "NOTIFY")

--- a/drivers/esphome_yale/driver.lua
+++ b/drivers/esphome_yale/driver.lua
@@ -510,16 +510,24 @@ local function setDoorSenseConfigured(configured)
   end
 end
 
+--- Last door status notified this session. In-memory on purpose: a driver
+--- restart clears it, so the bound consumer is re-notified even when the
+--- status matches the persisted variable.
+--- @type string|nil
+local lastNotifiedDoorStatus = nil
+
 --- Update the door status and notify dynamic contact sensor binding.
---- Persists state via the values lib so it survives reboots/driver updates.
---- Deduplicates: only sends a proxy notification when the state actually changes.
+--- Deduplicates within the session: only sends a proxy notification when the
+--- status changes or on the first reading after a driver start.
 --- @param doorStatus string "CLOSED" or "OPENED"
 local function updateDoorStatus(doorStatus)
   setDoorSenseConfigured(true)
 
-  if not values:update("Door Status", doorStatus) then
+  values:update("Door Status", doorStatus)
+  if lastNotifiedDoorStatus == doorStatus then
     return
   end
+  lastNotifiedDoorStatus = doorStatus
 
   log:info("Door status: %s", doorStatus)
 

--- a/src/esphome/entities/cover.lua
+++ b/src/esphome/entities/cover.lua
@@ -4,6 +4,12 @@ local values = require("lib.values")
 local ESPHomeClient = require("esphome.client")
 local ESPHomeProtoSchema = require("esphome.proto_schema")
 
+--- Last contact state notified per binding this session. In-memory on
+--- purpose: a driver restart clears it, so bound consumers are re-notified
+--- even when the state matches the persisted variable.
+--- @type table<string, string>
+local lastNotified = {}
+
 --- @class CoverEntity:Entity
 local CoverEntity = {
   TYPE = ESPHomeClient.EntityType.COVER,
@@ -207,14 +213,18 @@ function CoverEntity:updated(entity, state)
   local coverOpenBinding = bindings:getDynamicBinding(self.TYPE, "cover_open_" .. entity.key)
   if coverOpenBinding ~= nil then
     local coverOpenState = coverOpen and "CLOSED" or "OPENED"
-    if values:update(entity.name .. " Open", coverOpenState) then
+    values:update(entity.name .. " Open", coverOpenState)
+    if lastNotified["open_" .. entity.key] ~= coverOpenState then
+      lastNotified["open_" .. entity.key] = coverOpenState
       SendToProxy(coverOpenBinding.bindingId, coverOpenState, {}, "NOTIFY")
     end
   end
   local coverClosedBinding = bindings:getDynamicBinding(self.TYPE, "cover_closed_" .. entity.key)
   if coverClosedBinding ~= nil then
     local coverClosedState = coverClosed and "CLOSED" or "OPENED"
-    if values:update(entity.name .. " Closed", coverClosedState) then
+    values:update(entity.name .. " Closed", coverClosedState)
+    if lastNotified["closed_" .. entity.key] ~= coverClosedState then
+      lastNotified["closed_" .. entity.key] = coverClosedState
       SendToProxy(coverClosedBinding.bindingId, coverClosedState, {}, "NOTIFY")
     end
   end


### PR DESCRIPTION
Four drivers deduplicate proxy notifications by comparing against the **persisted** variable value (`if values:update(...)`/`if changed`). Persistence survives driver restarts, so the first reading of a new session is suppressed whenever it matches the stored value — and the bound consumer keeps whatever state it had until the device actually changes state:

- `cover.lua` contact sensors — a garage-door proxy sits on **Unknown** after a driver update until the door physically moves (observed on production during today's debugging: the one reload that healed it did so only because the persisted values happened to restore as nil)
- `esphome_yale` DoorSense contact (the docstring even said "Persists state via the values lib so it survives reboots" — that persistence is precisely the bug)
- `esphome_bthome` sensor and contact bindings
- `esphome_switchbot` Bot relay

## Fix

Deduplicate against an **in-memory** last-notified value per binding instead. Identical repeats within a session still drop (preserving the v20260325/v20260318-era duplicate-notification fixes), and a driver restart clears the memory so the first reading always goes out. The persisted variables are untouched — `values:update` still runs unconditionally.

`binary_sensor` and `esphome_govee` push unconditionally and never had the flaw. The same fix for the new sensor value bindings is in #70.

## Verification

- `luajit` syntax checks pass; stylua/mdformat idempotent; `make preprocess gen-squishy update-xml package` exits 0.
- Statically verified only — exercising it requires a driver reload against a device whose state matches persistence, which is exactly the hard-to-reproduce condition; the cover case was observed in the wild today.