### PR TITLE
Clear notify memos on driver reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ### Fixed
 
+- Fixed the Reset Driver action leaving bound consumers stale until the next
+  state change (sensor values, cover contacts, BTHome bindings, Yale DoorSense)
 - Fixed pending requests (refresh, Bluetooth GATT operations) hanging forever
   when the connection dropped mid-request; they now fail immediately with a
   "Disconnected" error

--- a/README.md
+++ b/README.md
@@ -910,6 +910,8 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ### Fixed
 
+- Fixed the Reset Driver action leaving bound consumers stale until the next
+  state change (sensor values, cover contacts, BTHome bindings, Yale DoorSense)
 - Fixed pending requests (refresh, Bluetooth GATT operations) hanging forever
   when the connection dropped mid-request; they now fail immediately with a
   "Disconnected" error

--- a/drivers/esphome/driver.lua
+++ b/drivers/esphome/driver.lua
@@ -654,6 +654,10 @@ function EC.Reset_Driver(params)
   -- Reset all values (variables and properties)
   values:reset()
 
+  -- Clear in-memory notify memos so recreated bindings receive the next state
+  CoverEntity.clearNotifiedState()
+  SensorEntity.clearNotifiedState()
+
   -- Reset BLE scanner state
   bleScanner:abortScan()
   bleScanner:reset()

--- a/drivers/esphome_bthome/driver.lua
+++ b/drivers/esphome_bthome/driver.lua
@@ -1039,6 +1039,8 @@ function EC.Reset_Driver(params)
   -- Reset local state
   knownObjects = {}
   cachedMacBytes = nil
+  -- Clear the in-memory notify memo so recreated bindings receive the next reading
+  lastNotified = {}
 
   -- Reset properties to defaults (excludes user-entered credentials)
   local resetValues = GetPropertyResetValues({ "Bind Key" })

--- a/drivers/esphome_yale/driver.lua
+++ b/drivers/esphome_yale/driver.lua
@@ -1744,6 +1744,9 @@ function EC.Reset_Driver(params)
   resetConnectionState(true)
   initialStatusTriggered = false
   doorSenseConfigured = nil
+  -- Clear the in-memory notify memo so a recreated contact binding receives
+  -- the next door status
+  lastNotifiedDoorStatus = nil
 
   -- Restore connection mode from property
   connectionMode = Properties["Connection Mode"] or CONNECTION_MODE.POLL

--- a/src/esphome/entities/cover.lua
+++ b/src/esphome/entities/cover.lua
@@ -16,6 +16,12 @@ local CoverEntity = {
 }
 CoverEntity.__index = CoverEntity
 
+--- Clear the in-memory notify memo so the next state dump re-notifies bound
+--- consumers (driver reset).
+function CoverEntity.clearNotifiedState()
+  lastNotified = {}
+end
+
 --- Create a new instance of the cover entity.
 --- @param client ESPHomeClient The ESPHome client instance.
 --- @return CoverEntity entity A new instance of the CoverEntity entity.

--- a/src/esphome/entities/sensor.lua
+++ b/src/esphome/entities/sensor.lua
@@ -66,6 +66,12 @@ end
 --- @type table<string, number>
 local lastPushed = {}
 
+--- Clear the in-memory push memo so the next reading re-notifies bound
+--- consumers (driver reset).
+function SensorEntity.clearNotifiedState()
+  lastPushed = {}
+end
+
 --- Build the dynamic binding key for a sensor entity.
 --- @param entity table<string, any> The entity data received from the ESPHome client.
 --- @return string key The dynamic binding key.


### PR DESCRIPTION
Fixes [DRV-60](https://youtrack.dmiller.me/issue/DRV-60) — the reset-path gap flagged in the #74 review, plus one site the ticket underestimated.

The in-memory notify memos clear on a driver restart but survive `EC.Reset_Driver`, which recreates dynamic bindings and wipes stored values expecting the next reading to resync consumers. The memo suppressed that first notify. One correction to the review's scope: the main esphome driver **does** have a `Reset_Driver` (`drivers/esphome/driver.lua:644`) with `bindings:reset()` + `values:reset()`, so cover.lua's memo — and sensor.lua's `lastPushed` from #70, which the ticket missed entirely — were both affected too.

## Changes

- `cover.lua` / `sensor.lua`: export `clearNotifiedState()` (static, reassigns the file-local memo upvalue); the main driver's `Reset_Driver` calls both after `values:reset()`
- `esphome_bthome`: `lastNotified = {}` in its `Reset_Driver`'s local-state block
- `esphome_yale`: `lastNotifiedDoorStatus = nil` in its `Reset_Driver`

switchbot needs nothing here: #74 (now in this branch's base) already clears all three of its memos via `clearNotifiedState()` on both its reset and rebind paths. With that, every notify memo in the repo clears on reset: bthome, yale, switchbot ×3, and the two entity modules.

Rebind (`OBC[ESPHOME_BINDING]`) paths deliberately unchanged: bthome only resets `knownObjects` there (its per-binding OBC handlers re-push on bind, as does sensor.lua's `sendCachedValue`), and yale's only calls `resetConnectionState`. Clearing memos there would invent new rebind semantics rather than restore old ones. The reviewer-confirmed gap that cover/yale contacts have no bind-time seeder at all is pre-existing #73 behavior, tracked separately.

On the shared-helper suggestion: skipped for now — each memo is file-local next to its gate, and a shared lib would still need per-driver clear wiring. Can revisit if the pattern spreads further.

## Verification

`luajit` syntax on all changed files, stylua/mdformat idempotent, full package build exits 0. Pure additions, 25 insertions.