### PR TITLE
Seed contact bindings with the last known state on bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ### Fixed
 
+- Fixed cover contacts and Yale DoorSense sending nothing to a newly bound
+  consumer (or after a DoorSense drop and re-detect) until the state changed;
+  consumers are now seeded with the last known state on bind
 - Fixed the Reset Driver action leaving bound consumers stale until the next
   state change (sensor values, cover contacts, BTHome bindings, Yale DoorSense)
 - Fixed pending requests (refresh, Bluetooth GATT operations) hanging forever

--- a/README.md
+++ b/README.md
@@ -910,6 +910,9 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ### Fixed
 
+- Fixed cover contacts and Yale DoorSense sending nothing to a newly bound
+  consumer (or after a DoorSense drop and re-detect) until the state changed;
+  consumers are now seeded with the last known state on bind
 - Fixed the Reset Driver action leaving bound consumers stale until the next
   state change (sensor values, cover contacts, BTHome bindings, Yale DoorSense)
 - Fixed pending requests (refresh, Bluetooth GATT operations) hanging forever

--- a/drivers/esphome_yale/driver.lua
+++ b/drivers/esphome_yale/driver.lua
@@ -488,6 +488,32 @@ local function updateLockStatus(status)
   SendToProxy(PROXY_BINDING, "LOCK_STATUS_CHANGED", { LOCK_STATUS = status }, "NOTIFY")
 end
 
+--- Last door status notified this session. In-memory on purpose: a driver
+--- restart clears it, so the bound consumer is re-notified even when the
+--- status matches the persisted variable.
+--- @type string|nil
+local lastNotifiedDoorStatus = nil
+
+--- Register a bind-time seeder on the door contact binding that sends the
+--- last known door status to a newly bound consumer. The send bypasses the
+--- notify memo, matching the sensor value seed. No-op if the binding is gone.
+local function registerDoorContactSeeder()
+  local binding = bindings:getDynamicBinding(BINDINGS_NAMESPACE, "door")
+  if not binding then
+    return
+  end
+  OBC[binding.bindingId] = function(idBinding, _strClass, bIsBound, _otherDeviceId, _otherBindingId)
+    log:trace("OBC[%s](%s, %s)", binding.bindingId, idBinding, bIsBound)
+    if not bIsBound then
+      return
+    end
+    local doorStatus = Select(values:getValue("Door Status"), "value")
+    if not IsEmpty(doorStatus) then
+      SendToProxy(binding.bindingId, doorStatus, {}, "NOTIFY")
+    end
+  end
+end
+
 --- Enable or disable DoorSense contact sensor based on detection.
 --- When DoorSense is configured on the lock, creates a dynamic CONTACT_SENSOR binding
 --- and shows the Door Status property. When not configured, removes the binding and hides it.
@@ -501,20 +527,18 @@ local function setDoorSenseConfigured(configured)
   if configured then
     log:info("DoorSense detected - creating contact sensor binding")
     bindings:getOrAddDynamicBinding(BINDINGS_NAMESPACE, "door", "PROXY", true, "Door", "CONTACT_SENSOR")
+    registerDoorContactSeeder()
     C4:SetPropertyAttribs("Door Status", constants.SHOW_PROPERTY)
   else
     log:info("DoorSense not configured - removing contact sensor binding")
     bindings:deleteBinding(BINDINGS_NAMESPACE, "door")
+    -- The binding is gone; drop the memo so a later DoorSense redetection
+    -- re-notifies the recreated binding instead of deduping against it.
+    lastNotifiedDoorStatus = nil
     UpdateProperty("Door Status", "")
     C4:SetPropertyAttribs("Door Status", constants.HIDE_PROPERTY)
   end
 end
-
---- Last door status notified this session. In-memory on purpose: a driver
---- restart clears it, so the bound consumer is re-notified even when the
---- status matches the persisted variable.
---- @type string|nil
-local lastNotifiedDoorStatus = nil
 
 --- Update the door status and notify dynamic contact sensor binding.
 --- Deduplicates within the session: only sends a proxy notification when the
@@ -1243,6 +1267,7 @@ function OnDriverLateInit()
   local doorBinding = bindings:getDynamicBinding(BINDINGS_NAMESPACE, "door")
   if doorBinding then
     doorSenseConfigured = true
+    registerDoorContactSeeder()
     C4:SetPropertyAttribs("Door Status", constants.SHOW_PROPERTY)
   else
     doorSenseConfigured = nil

--- a/src/esphome/entities/cover.lua
+++ b/src/esphome/entities/cover.lua
@@ -22,6 +22,24 @@ function CoverEntity.clearNotifiedState()
   lastNotified = {}
 end
 
+--- Register a bind-time seeder that sends the last known contact state to a
+--- newly bound consumer. The send bypasses the notify memo, matching the
+--- sensor value seed.
+--- @param bindingId number The contact binding ID.
+--- @param valueName string The values key holding the contact state.
+local function registerContactSeeder(bindingId, valueName)
+  OBC[bindingId] = function(idBinding, _strClass, bIsBound, _otherDeviceId, _otherBindingId)
+    log:trace("OBC[%s](%s, %s)", bindingId, idBinding, bIsBound)
+    if not bIsBound then
+      return
+    end
+    local state = Select(values:getValue(valueName), "value")
+    if not IsEmpty(state) then
+      SendToProxy(bindingId, state, {}, "NOTIFY")
+    end
+  end
+end
+
 --- Create a new instance of the cover entity.
 --- @param client ESPHomeClient The ESPHome client instance.
 --- @return CoverEntity entity A new instance of the CoverEntity entity.
@@ -40,7 +58,7 @@ function CoverEntity:discovered(entity)
   local supportsPosition = toboolean(entity.supports_position)
 
   -- Contacts
-  assert(
+  local coverClosedContactId = assert(
     bindings:getOrAddDynamicBinding(
       self.TYPE,
       "cover_closed_" .. entity.key,
@@ -49,8 +67,8 @@ function CoverEntity:discovered(entity)
       entity.name .. " Closed",
       "CONTACT_SENSOR"
     )
-  )
-  assert(
+  ).bindingId
+  local coverOpenContactId = assert(
     bindings:getOrAddDynamicBinding(
       self.TYPE,
       "cover_open_" .. entity.key,
@@ -59,7 +77,9 @@ function CoverEntity:discovered(entity)
       entity.name .. " Open",
       "CONTACT_SENSOR"
     )
-  )
+  ).bindingId
+  registerContactSeeder(coverClosedContactId, entity.name .. " Closed")
+  registerContactSeeder(coverOpenContactId, entity.name .. " Open")
 
   -- Relays
   local openCoverBindingId = assert(


### PR DESCRIPTION
Fixes [DRV-62](https://youtrack.dmiller.me/issue/DRV-62), the gap confirmed in the #78 review: cover's `cover_open_*`/`cover_closed_*` contacts and yale's `door` contact had no bind-time seeder, so a newly bound consumer sat stale until the physical state changed — with the notify memo suppressing the resync. Sensor values (`sendCachedValue` OBC), BTHome (per-binding OBC re-push), and SwitchBot (memo clear in its OBC) all already handle bind; these two were the odd ones out.

## Changes

- `cover.lua`: `registerContactSeeder(bindingId, valueName)` registers an OBC per contact binding that sends the stored `<name> Open`/`<name> Closed` value (`CLOSED`/`OPENED`) on `bIsBound`. `discovered()` now captures the contact binding ids and registers both seeders — `discovered()` runs on every connect, so the handlers exist every session.
- `esphome_yale`: `registerDoorContactSeeder()` sends `lastNotifiedDoorStatus` (this-session truth) falling back to the persisted `Door Status` value. Registered from **both** the `setDoorSenseConfigured(true)` create path and the `OnDriverLateInit` restore path — the restore sets `doorSenseConfigured` directly, which would otherwise early-return the create path and leave the session without a handler. The memo declaration moved above the seeder for upvalue capture (declaration order, per the #74 lesson).

Seeds bypass the memo and don't record it, matching bthome/sensor: worst case is one redundant idempotent notify on the next state dump.

Known tradeoff (same as the sensor seed, noted in the #73/#74 reviews): the persisted fallback can be stale if the device changed while the driver was down; the next real state dump corrects it because the memo comparison still sees the change.

## Verification

`luajit` syntax on both files, stylua/mdformat idempotent, full package build exits 0.