### PR TITLE
Serialize status refreshes to avoid callback displacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ### Fixed
 
+- Fixed overlapping status refreshes silently racing each other for the same
+  response callbacks; refreshes are now serialized and a displaced request
+  callback logs a warning
 - Fixed cover contacts and Yale DoorSense sending nothing to a newly bound
   consumer (or after a DoorSense drop and re-detect) until the state changed;
   consumers are now seeded with the last known state on bind

--- a/README.md
+++ b/README.md
@@ -910,6 +910,9 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ### Fixed
 
+- Fixed overlapping status refreshes silently racing each other for the same
+  response callbacks; refreshes are now serialized and a displaced request
+  callback logs a warning
 - Fixed cover contacts and Yale DoorSense sending nothing to a newly bound
   consumer (or after a DoorSense drop and re-detect) until the state changed;
   consumers are now seeded with the last known state on bind

--- a/drivers/esphome/driver.lua
+++ b/drivers/esphome/driver.lua
@@ -511,12 +511,37 @@ function Connect()
   heartbeat()
 end
 
+--- Whether a refresh chain is currently in flight. The ESPHome API has no
+--- request correlation, so two concurrent refreshes would displace each
+--- other's response callbacks in the client registry; refreshes are
+--- serialized instead.
+local refreshInFlight = false
+
 function RefreshStatus()
   log:trace("RefreshStatus()")
   -- Debounce the status refresh calls
   SetTimer("RefreshStatus", ONE_SECOND * 3, function()
-    esphome
-      :getDeviceInfo()
+    if refreshInFlight then
+      -- Re-arm and try again once the running chain settles (every chain
+      -- settles: responses and timeouts resolve it, disconnect rejects it).
+      log:debug("Status refresh already in flight; retrying after it settles")
+      RefreshStatus()
+      return
+    end
+    refreshInFlight = true
+    -- sendMessage can raise synchronously (encode, handshake assert, write);
+    -- the chain's error handler only exists once the deferred is returned, so
+    -- a raise here must clear the flag itself or it wedges permanently.
+    local ok, result = pcall(esphome.getDeviceInfo, esphome)
+    if not ok then
+      refreshInFlight = false
+      local startError = tostring(result or "unknown error")
+      log:error("An error occurred refreshing device status; %s", startError)
+      updateStatus("Refresh failed: " .. startError)
+      esphome:disconnect()
+      return
+    end
+    result
       :next(function(deviceInfo)
         log:debug("Device Info: %s", deviceInfo)
         -- First successful operation confirms authentication succeeded
@@ -609,8 +634,10 @@ function RefreshStatus()
         end
       end)
       :next(function()
+        refreshInFlight = false
         log:info("Successfully refreshed device status")
       end, function(error)
+        refreshInFlight = false
         if type(error) ~= "string" then
           error = "unknown error"
         end
@@ -680,6 +707,8 @@ function EC.Reset_Driver(params)
   -- Password, Encryption Key, and Use OpenSSL based on preserved setting
   OnPropertyChanged("Authentication Mode")
 
+  -- Escape hatch: never let a wedged in-flight flag survive a driver reset
+  refreshInFlight = false
   RefreshStatus()
 end
 

--- a/src/esphome/client.lua
+++ b/src/esphome/client.lua
@@ -1916,6 +1916,12 @@ function ESPHomeClient:_registerCallback(key, callback, timeout, onTimeout)
   if existing and existing.timer then
     existing.timer:Cancel()
   end
+  if existing and existing.onAbort then
+    -- The displaced waiter cannot be settled safely from here: its abort
+    -- handlers may unregister keys the new entry now owns. Callers must
+    -- serialize same-type requests instead (e.g. RefreshStatus).
+    log:warn("Displacing a pending request callback for key: %s", key)
+  end
 
   --- @type CallbackEntry
   local entry = {


### PR DESCRIPTION
Mitigates [DRV-61](https://youtrack.dmiller.me/issue/DRV-61) — deliberately not a full fix; the analysis of why is below and on the ticket.

## Problem

The ESPHome native API has no request correlation ids, so two concurrent requests awaiting the same response type displace each other in `_callbacks`: the loser's timer is cancelled and its chain never settles. The realistic collision source is the refresh chain (`getDeviceInfo` → `listEntities` → `subscribeStates`): the 3s debounce coalesces bursts, but a chain running longer than the debounce window (slow device, timeout territory) races the next trigger — e.g. several cover relay `OBC → RefreshStatus` firings during a project reload.

## Change

- `RefreshStatus` gains an in-flight flag: if the debounce timer fires mid-chain, it re-arms and retries after the chain settles. Every chain settles — responses/timeouts resolve it, and since #75 a disconnect rejects it — so the flag cannot deadlock.
- `_registerCallback` logs a warning when a collision displaces a pending request waiter, so any remaining occurrence is visible instead of silent.

## Why not settle the displaced waiter (the ticket's suggested fix)

Verified two concrete regressions it would cause:

1. **Key crossfire.** Abort handlers unregister sibling keys by name (`listEntities` unregisters all its collector keys; GATT ops unregister via their deferred cleanup). Keys are shared strings, so the displaced loser's cleanup would remove the *winner's* freshly registered entries — trading a stranded loser for a stranded winner. A full fix needs identity-checked unregistration (handles instead of raw keys through ~25 call sites).
2. **Supersede-as-failure.** A superseded refresh rejects into `RefreshStatus`'s error handler, which calls `updateStatus("Refresh failed")` + `esphome:disconnect()` — tearing down the winning refresh's connection. Today the newest refresh wins cleanly; abort-on-displace would make both lose.

Remaining exposure after this PR: non-refresh same-key concurrency (e.g. two GATT ops on the same address+handle) still displaces silently-but-warned. DRV-61 stays open for the handle-based refactor if the warning ever shows up in practice.

## Verification

`luajit` syntax on both files, stylua/mdformat idempotent, full package build exits 0.