### PR TITLE
Map the open lock states to unlocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ### Fixed
 
+- Fixed latch-style ESPHome locks (`supports_open`) reading as "unknown" in
+  Control4 while reporting the open or opening state; both now map to unlocked
 - Fixed overlapping status refreshes silently racing each other for the same
   response callbacks; refreshes are now serialized and a displaced request
   callback logs a warning

--- a/README.md
+++ b/README.md
@@ -910,6 +910,8 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ### Fixed
 
+- Fixed latch-style ESPHome locks (`supports_open`) reading as "unknown" in
+  Control4 while reporting the open or opening state; both now map to unlocked
 - Fixed overlapping status refreshes silently racing each other for the same
   response callbacks; refreshes are now serialized and a displaced request
   callback logs a warning

--- a/drivers/esphome_lock/driver.lua
+++ b/drivers/esphome_lock/driver.lua
@@ -178,6 +178,10 @@ local function convertLockStateToStatus(lockState)
     return "unlocked"
   elseif lockState == ESPHomeProtoSchema.Enum.LockState.LOCK_STATE_UNLOCKING then
     return "locked"
+  elseif lockState == ESPHomeProtoSchema.Enum.LockState.LOCK_STATE_OPENING then
+    return "unlocked"
+  elseif lockState == ESPHomeProtoSchema.Enum.LockState.LOCK_STATE_OPEN then
+    return "unlocked"
   end
   return "unknown"
 end


### PR DESCRIPTION
Fixes [DRV-57](https://youtrack.dmiller.me/issue/DRV-57).

`convertLockStateToStatus()` handled 5 of the 8 `LockState` values; `LOCK_STATE_OPENING` (6) and `LOCK_STATE_OPEN` (7) fell through to `"unknown"`, so any `supports_open` lock (latch/strike platforms) read as unknown in Navigator whenever open.

## Decision on the ticket's open question

Both map to `"unlocked"` — the pragmatic collapse the ticket proposed. The C4 lock proxy has no distinct open concept. Per review: ESPHome's `Lock::open()` calls `open_latch()` with no guard on current state, so `LOCKED → OPENING` is reachable and `unlocked` is right as the safer transient reading that converges on `OPEN` being genuinely not locked (not because the predecessor state is guaranteed unlocked). If surfacing open/opening distinctly ever matters, a driver variable can be added as a follow-up without changing this mapping.

`toggle()` is left as-is: a lock sitting in `OPEN` still gets `lock()` on toggle, which the ticket agrees is the desired outcome. The unused `LOCK_COMMAND.LOCK_OPEN` (no C4 path issues the open action) is tracked separately as DRV-64.

## Verification

`luajit` syntax check, stylua/mdformat idempotent, full package build exits 0. No `supports_open` lock exists in the rack (per the ticket); the ticket's suggested unit-level enum sweep needs driver-load scaffolding the harness doesn't have, so it stays with the ticket's verification note.