### PR TITLE
Map defrosting to Heating and warn on unmapped climate values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ### Fixed
 
+- Fixed the HVAC state freezing on the previous value during a heat pump's
+  defrost cycle; defrosting now reports as Heating, and unmapped climate
+  modes/actions log a warning instead of being silently dropped
 - Fixed latch-style ESPHome locks (`supports_open`) reading as "unknown" in
   Control4 while reporting the open or opening state; both now map to unlocked
 - Fixed overlapping status refreshes silently racing each other for the same

--- a/README.md
+++ b/README.md
@@ -910,6 +910,9 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ### Fixed
 
+- Fixed the HVAC state freezing on the previous value during a heat pump's
+  defrost cycle; defrosting now reports as Heating, and unmapped climate
+  modes/actions log a warning instead of being silently dropped
 - Fixed latch-style ESPHome locks (`supports_open`) reading as "unknown" in
   Control4 while reporting the open or opening state; both now map to unlocked
 - Fixed overlapping status refreshes silently racing each other for the same

--- a/drivers/esphome_climate/driver.lua
+++ b/drivers/esphome_climate/driver.lua
@@ -81,6 +81,8 @@ local CLIMATE_ACTION_TO_C4 = {
   [ESPHomeProtoSchema.Enum.ClimateAction.CLIMATE_ACTION_IDLE] = "Idle",
   [ESPHomeProtoSchema.Enum.ClimateAction.CLIMATE_ACTION_DRYING] = "Drying",
   [ESPHomeProtoSchema.Enum.ClimateAction.CLIMATE_ACTION_FAN] = "Fan Only",
+  -- Defrost is a heating-cycle sub-state; the C4 proxy has no defrost state
+  [ESPHomeProtoSchema.Enum.ClimateAction.CLIMATE_ACTION_DEFROSTING] = "Heating",
 }
 
 --- ESPHome ClimateFanMode -> C4 fan mode string
@@ -896,6 +898,12 @@ function RFP.UPDATE_DISCONNECT(idBinding, strCommand, tParams, args)
   SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = false }, "NOTIFY")
 end
 
+--- Last unmapped mode/action warned about. State pushes repeat every few
+--- seconds (temperature changes included), so warn once per value, not per
+--- push.
+local warnedMode = nil
+local warnedAction = nil
+
 function RFP.UPDATE_STATE(idBinding, strCommand, tParams, args)
   log:trace("RFP.UPDATE_STATE(%s, %s, %s, %s)", idBinding, strCommand, tParams, args)
   if idBinding ~= ESPHOME_BINDING then
@@ -945,6 +953,9 @@ function RFP.UPDATE_STATE(idBinding, strCommand, tParams, args)
     local c4Mode = CLIMATE_MODE_TO_C4[mode]
     if c4Mode ~= nil then
       SendToProxy(PROXY_BINDING, "HVAC_MODE_CHANGED", { MODE = c4Mode }, "NOTIFY")
+    elseif warnedMode ~= mode then
+      warnedMode = mode
+      log:warn("Unmapped ESPHome climate mode %s; HVAC mode not updated", mode)
     end
   end
 
@@ -954,6 +965,9 @@ function RFP.UPDATE_STATE(idBinding, strCommand, tParams, args)
     local c4State = CLIMATE_ACTION_TO_C4[action]
     if c4State ~= nil then
       SendToProxy(PROXY_BINDING, "HVAC_STATE_CHANGED", { STATE = c4State }, "NOTIFY")
+    elseif warnedAction ~= action then
+      warnedAction = action
+      log:warn("Unmapped ESPHome climate action %s; HVAC state not updated", action)
     end
   end
 


### PR DESCRIPTION
Fixes [DRV-58](https://youtrack.dmiller.me/issue/DRV-58).

`CLIMATE_ACTION_DEFROSTING` (7) was absent from `CLIMATE_ACTION_TO_C4`, and the nil-guarded lookup meant no `HVAC_STATE_CHANGED` was sent at all — C4 kept displaying the previous action for the entire defrost cycle, exactly when someone on a heat pump in cold weather is most likely to be looking.

## Decisions on the ticket's open points

- **Mapping: `Heating`** (the ticket's candidate 1). Defrost is a heating-cycle sub-state with the compressor running, and it's an already-accepted proxy STATE value, so no proxy-tolerance experiment is needed. A dedicated string was rejected: thermostatV2 consumers constrain STATE, and an unrecognized value risks trading a stale display for a broken one.
- **The underlying silent-swallow**: both the mode and action lookups now `log:warn` on unmapped values, per the ticket — the next ESPHome enum addition shows up in logs instead of as a frozen thermostat.

## Verification

`luajit` syntax check, stylua/mdformat idempotent, full package build exits 0. No heat pump on the bench reports defrost on demand (per the ticket); the harness only supports live-device integration runs, so the suggested unit-level enum sweep stays with the ticket's verification note.