### PR TITLE
Add an Open Latch action to the lock driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ## Unreleased
 
+### Added
+
+- Added an "Open Latch" action to the ESPHome Lock driver for locks that support
+  the open command (`supports_open`)
+
 ### Fixed
 
 - Fixed the HVAC state freezing on the previous value during a heat pump's

--- a/README.md
+++ b/README.md
@@ -908,6 +908,11 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ## Unreleased
 
+### Added
+
+- Added an "Open Latch" action to the ESPHome Lock driver for locks that support
+  the open command (`supports_open`)
+
 ### Fixed
 
 - Fixed the HVAC state freezing on the previous value during a heat pump's

--- a/drivers/esphome_lock/driver.lua
+++ b/drivers/esphome_lock/driver.lua
@@ -128,6 +128,33 @@ local function lock()
   })
 end
 
+--- Open the latch on locks that support the open action.
+local function open()
+  log:trace("open()")
+  local code = not IsEmpty(Properties["Lock Code"]) and Properties["Lock Code"] or nil
+  SendToProxy(ESPHOME_BINDING, "ENTITY_COMMAND", {
+    body = SerializeSafe({
+      command = ESPHomeProtoSchema.Enum.LockCommand.LOCK_OPEN,
+      has_code = code ~= nil,
+      code = code,
+    }),
+  })
+end
+
+function EC.Open_Latch()
+  log:trace("EC.Open_Latch()")
+  local supportsOpen = Select(ENTITY, "supports_open")
+  if supportsOpen == nil then
+    log:warn("Lock entity has not been discovered yet; cannot verify open support")
+    return
+  end
+  if not toboolean(supportsOpen) then
+    log:warn("The lock does not support the open action")
+    return
+  end
+  open()
+end
+
 local function toggle()
   log:trace("toggle()")
   local state = tointeger(Select(STATE, "state")) or 0

--- a/drivers/esphome_lock/driver.xml
+++ b/drivers/esphome_lock/driver.xml
@@ -95,8 +95,18 @@
         <default/>
       </property>
     </properties>
-    <commands/>
-    <actions/>
+    <commands>
+      <command>
+        <name>Open Latch</name>
+        <description>Open the latch on NAME</description>
+      </command>
+    </commands>
+    <actions>
+      <action>
+        <name>Open Latch</name>
+        <command>Open_Latch</command>
+      </action>
+    </actions>
   </config>
   <capabilities>
     <is_management_only>False</is_management_only>

--- a/drivers/esphome_lock/www/documentation/index.md
+++ b/drivers/esphome_lock/www/documentation/index.md
@@ -44,6 +44,7 @@ allowing them to be controlled through the Control4 lock proxy.
     - [Driver Settings](#driver-settings)
     - [Device Settings](#device-settings)
   - [Connections](#connections)
+  - [Driver Actions](#driver-actions)
   <!-- #ifdef DRIVERCENTRAL -->
 - [Developer Information](#developer-information)
 
@@ -66,6 +67,8 @@ allowing them to be controlled through the Control4 lock proxy.
 
 - Control4 Lock Proxy integration for native Control4 lock control
 - Lock, unlock, and toggle commands with optional lock code support
+- Open Latch action and programming command for latch-style locks that support
+  the open action
 - Real-time state synchronization with ESPHome device
 
 <div style="page-break-after: always"></div>
@@ -136,6 +139,17 @@ and provides the lock functionality to Control4.
 ### ESPHome Lock (consumer)
 
 Bind this connection to the lock entity exposed by the main ESPHome driver.
+
+## Driver Actions
+
+### Open Latch
+
+Opens the latch on locks that support the open action (`supports_open`). Also
+available as a device-specific command in Composer programming, so the latch can
+be opened from automation (for example, on a doorbell press). Uses the
+configured **Lock Code** when one is set. Logs a warning and does nothing if the
+connected lock does not support open, or if the lock entity has not been
+discovered yet.
 
 <div style="page-break-after: always"></div>
 


### PR DESCRIPTION
Fixes [DRV-64](https://youtrack.dmiller.me/issue/DRV-64), the follow-up from the #83 reviews.

The schema defines `LockCommand.LOCK_OPEN` and `supports_open` locks accept it (`Lock::open()` → `open_latch()`), but the driver only ever issued `LOCK_LOCK`/`LOCK_UNLOCK`.

## Changes

- `driver.xml`: an **Open Latch** action (Composer Actions tab + device-specific programming command).
- `driver.lua`: `open()` mirrors `lock()`/`unlock()` — same `ENTITY_COMMAND` path, same `Lock Code` handling. `EC.Open_Latch` gates on the discovered entity's `supports_open` and no-ops with a warning otherwise (actions are static XML, so the gate is runtime).

## Verification

`luajit` syntax, stylua/mdformat idempotent, full package build exits 0. No `supports_open` lock in the rack (same constraint noted on DRV-57/#83), so exercised statically; the command construction is byte-for-byte the `lock()`/`unlock()` shape with a different enum.