### PR TITLE
Add a Connected variable to every driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ### Added
 
+- Added a `Connected` (BOOL) variable to the main driver and every sub-driver
+  with a Driver Status so Programming can react to connect/disconnect
 - Added an "Open Latch" action to the ESPHome Lock driver for locks that support
   the open command (`supports_open`)
 

--- a/README.md
+++ b/README.md
@@ -910,6 +910,8 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ### Added
 
+- Added a `Connected` (BOOL) variable to the main driver and every sub-driver
+  with a Driver Status so Programming can react to connect/disconnect
 - Added an "Open Latch" action to the ESPHome Lock driver for locks that support
   the open command (`supports_open`)
 

--- a/drivers/esphome/driver.lua
+++ b/drivers/esphome/driver.lua
@@ -400,9 +400,20 @@ function OPC.Minimum_Room_RSSI_Override_dBm(propertyValue)
   bluetoothProxyCapability:onMinRssiOverrideChanged()
 end
 
-local function updateStatus(status)
-  log:trace("updateStatus(%s)", status)
-  UpdateProperty("Driver Status", not IsEmpty(status) and status or "Unknown")
+--- Update the Driver Status property and the Connected variable so
+--- Programming can react to connect/disconnect.
+--- @param status string The human-readable connection status.
+--- @param connected boolean Whether this status represents a live connection;
+--- callers pass it explicitly so rewording a status can never silently flip
+--- the Connected variable.
+local function updateStatus(status, connected)
+  log:trace("updateStatus(%s, %s)", status, connected)
+  status = not IsEmpty(status) and status or "Unknown"
+  if type(connected) ~= "boolean" then
+    error(string.format("updateStatus(%s): connected must be an explicit boolean", tostring(status)), 2)
+  end
+  UpdateProperty("Driver Status", status)
+  values:update("Connected", connected, "BOOL")
 end
 
 --- Backoff period in seconds after a fatal connection error before retrying.
@@ -411,7 +422,7 @@ local FATAL_ERROR_BACKOFF = 120
 function Connect()
   log:trace("Connect()")
   if not gInitialized then
-    updateStatus("Initializing...")
+    updateStatus("Initializing...", false)
     return
   end
 
@@ -441,13 +452,13 @@ function Connect()
   local heartbeat = function()
     --#ifdef DRIVERCENTRAL
     if DC_X == 0 then
-      updateStatus("No active license")
+      updateStatus("No active license", false)
       esphome:disconnect()
       return
     end
     --#endif
     if not esphome:isConfigured() then
-      updateStatus("Not configured")
+      updateStatus("Not configured", false)
       esphome:disconnect()
       CancelTimer("heartbeat")
       return
@@ -480,23 +491,23 @@ function Connect()
         local secondsSinceFailure = now - lastFatalErrorTime
         if secondsSinceFailure < FATAL_ERROR_BACKOFF then
           local remaining = FATAL_ERROR_BACKOFF - secondsSinceFailure
-          updateStatus(fatalError .. " (retry in " .. remaining .. "s)")
+          updateStatus(fatalError .. " (retry in " .. remaining .. "s)", false)
           return
         end
         -- Backoff period elapsed, reset and try again
         lastFatalErrorTime = 0
       end
 
-      updateStatus("Connecting")
+      updateStatus("Connecting", false)
       esphome:connect():next(function()
         lastFatalErrorTime = 0 -- Clear on successful connection
         wasConnected = true
         -- If using password authentication, show "waiting for authentication" status
         -- until first successful operation confirms auth succeeded
         if Properties["Authentication Mode"] == "Password" and not IsEmpty(Properties["Password"]) then
-          updateStatus("Connection established, waiting for authentication")
+          updateStatus("Connection established, waiting for authentication", false)
         else
-          updateStatus("Connected")
+          updateStatus("Connected", true)
         end
         RefreshStatus()
       end, function(reason)
@@ -505,10 +516,10 @@ function Connect()
           log:debug("Connection attempt superseded by a newer one; leaving the status to it")
           return
         end
-        updateStatus("Connection failed: " .. reason)
+        updateStatus("Connection failed: " .. reason, false)
       end)
     else
-      updateStatus("Connected")
+      updateStatus("Connected", true)
     end
   end
   -- Perform the initial refresh then schedule it on a repeating timer
@@ -542,7 +553,7 @@ function RefreshStatus()
       refreshInFlight = false
       local startError = tostring(result or "unknown error")
       log:error("An error occurred refreshing device status; %s", startError)
-      updateStatus("Refresh failed: " .. startError)
+      updateStatus("Refresh failed: " .. startError, false)
       esphome:disconnect()
       return
     end
@@ -550,7 +561,7 @@ function RefreshStatus()
       :next(function(deviceInfo)
         log:debug("Device Info: %s", deviceInfo)
         -- First successful operation confirms authentication succeeded
-        updateStatus("Connected")
+        updateStatus("Connected", true)
         values:update("Name", esphome:getDeviceName() or "N/A", "STRING")
         values:update("Model", Select(deviceInfo, "model") or "N/A", "STRING")
         values:update("Manufacturer", Select(deviceInfo, "manufacturer") or "N/A", "STRING")
@@ -656,7 +667,7 @@ function RefreshStatus()
           error = "unknown error"
         end
         log:error("An error occurred refreshing device status; %s", error)
-        updateStatus("Refresh failed: " .. error)
+        updateStatus("Refresh failed: " .. error, false)
         esphome:disconnect()
       end)
   end)

--- a/drivers/esphome_bluetooth_coordinator/driver.lua
+++ b/drivers/esphome_bluetooth_coordinator/driver.lua
@@ -29,6 +29,21 @@ local presenceTracker = require("esphome.ble.coordinator.presence_tracker")
 local bleScanner = require("esphome.ble.scanner")
 local bleScannerProperties = require("esphome.ble.scanner_properties")
 
+--- Update the Driver Status property and the Connected variable so
+--- Programming can react to connect/disconnect.
+--- @param status string The human-readable connection status.
+--- @param connected boolean Whether this status represents a live connection;
+--- callers pass it explicitly so rewording a status can never silently flip
+--- the Connected variable.
+local function updateStatus(status, connected)
+  log:trace("updateStatus(%s, %s)", status, connected)
+  if type(connected) ~= "boolean" then
+    error(string.format("updateStatus(%s): connected must be an explicit boolean", tostring(status)), 2)
+  end
+  UpdateProperty("Driver Status", status)
+  values:update("Connected", connected, "BOOL")
+end
+
 --------------------------------------------------------------------------------
 -- Constants
 --------------------------------------------------------------------------------
@@ -363,6 +378,9 @@ function EC.Reset_Driver(tParams)
   -- Delete all dynamic bindings
   bindings:deleteAllBindings(BINDINGS_NAMESPACE)
 
+  -- Remove the connection state variables alongside the rest of the state
+  values:reset()
+
   updateStatusProperties()
 end
 
@@ -631,13 +649,13 @@ function OnDriverLateInit()
 
   --#ifdef DRIVERCENTRAL
   if DC_X == 0 then
-    C4:UpdateProperty("Driver Status", "No active license")
+    updateStatus("No active license", false)
     return
   end
   --#endif
 
   log:info("Initializing Bluetooth Coordinator")
-  C4:UpdateProperty("Driver Status", "Initializing...")
+  updateStatus("Initializing...", false)
 
   -- Restore persisted events (C4:AddEvent is unavailable before OnDriverLateInit)
   events:restoreEvents()
@@ -656,7 +674,7 @@ function OnDriverLateInit()
 
   -- Update status
   updateStatusProperties()
-  C4:UpdateProperty("Driver Status", "Running")
+  updateStatus("Running", true)
 
   -- Fire OnPropertyChanged for all properties to initialize OPC handlers
   -- This runs while initialized=false, so handlers that check initialized will skip

--- a/drivers/esphome_bthome/driver.lua
+++ b/drivers/esphome_bthome/driver.lua
@@ -19,6 +19,21 @@ local constants = require("constants")
 local BTHome = require("bthome")
 local UUID = require("esphome.ble.uuid")
 
+--- Update the Driver Status property and the Connected variable so
+--- Programming can react to connect/disconnect.
+--- @param status string The human-readable connection status.
+--- @param connected boolean Whether this status represents a live connection;
+--- callers pass it explicitly so rewording a status can never silently flip
+--- the Connected variable.
+local function updateStatus(status, connected)
+  log:trace("updateStatus(%s, %s)", status, connected)
+  if type(connected) ~= "boolean" then
+    error(string.format("updateStatus(%s): connected must be an explicit boolean", tostring(status)), 2)
+  end
+  UpdateProperty("Driver Status", status)
+  values:update("Connected", connected, "BOOL")
+end
+
 --------------------------------------------------------------------------------
 -- Constants
 --------------------------------------------------------------------------------
@@ -800,7 +815,7 @@ function OnDriverLateInit()
   end
 
   gInitialized = true
-  UpdateProperty("Driver Status", "Waiting for data")
+  updateStatus("Waiting for data", false)
 
   -- Request refresh from parent driver
   SendToProxy(ESPHOME_BINDING, "REFRESH_STATE", {}, "NOTIFY")
@@ -889,7 +904,7 @@ function OPC.Bind_Key(propertyValue)
   cachedBindKey = table.concat(bytes)
   log:info("Bind key configured (%d bytes)", #cachedBindKey)
 
-  UpdateProperty("Driver Status", "Waiting for data")
+  updateStatus("Waiting for data", false)
 end
 
 --------------------------------------------------------------------------------
@@ -928,7 +943,7 @@ function RFP.CONNECTED_PASSIVE(idBinding, strCommand, tParams, args)
     end
   end
 
-  UpdateProperty("Driver Status", "Listening")
+  updateStatus("Listening", true)
 end
 
 --- Handle incoming BLE advertisement from parent driver
@@ -964,7 +979,7 @@ function RFP.BLE_ADVERTISEMENT(idBinding, strCommand, tParams, args)
   -- Parse BTHome data (pass cached bind key and MAC for encrypted devices)
   local result, err = BTHome.parse(uuid, serviceData, cachedBindKey, cachedMacBytes)
   if not result then
-    UpdateProperty("Driver Status", "Error: " .. (err or "unknown"))
+    updateStatus("Error: " .. (err or "unknown"), false)
     return
   end
 
@@ -980,7 +995,7 @@ function RFP.BLE_ADVERTISEMENT(idBinding, strCommand, tParams, args)
   end
 
   -- Update status
-  UpdateProperty("Driver Status", "Listening")
+  updateStatus("Listening", true)
 
   -- Process the data
   processBTHomeReadings(result.readings, advertisement.rssi)
@@ -995,7 +1010,7 @@ function RFP.DISCONNECTED(idBinding, strCommand, tParams, args)
 
   local reason = Select(tParams, "reason") or "unknown"
   log:info("BTHome device disconnected: %s", reason)
-  UpdateProperty("Driver Status", "Waiting for data")
+  updateStatus("Waiting for data", false)
 end
 
 --------------------------------------------------------------------------------
@@ -1009,9 +1024,9 @@ OBC[ESPHOME_BINDING] = function(idBinding, strClass, bIsBound, otherDeviceId)
   knownObjects = {}
 
   if bIsBound then
-    UpdateProperty("Driver Status", "Waiting for data")
+    updateStatus("Waiting for data", false)
   else
-    UpdateProperty("Driver Status", "Disconnected")
+    updateStatus("Disconnected", false)
   end
 end
 

--- a/drivers/esphome_climate/driver.lua
+++ b/drivers/esphome_climate/driver.lua
@@ -12,9 +12,25 @@ JSON = require("JSON")
 local ESPHomeProtoSchema = require("esphome.proto_schema")
 
 local log = require("lib.logging")
+local values = require("lib.values")
 local constants = require("constants")
 local bindings = require("lib.bindings")
 local persist = require("lib.persist")
+
+--- Update the Driver Status property and the Connected variable so
+--- Programming can react to connect/disconnect.
+--- @param status string The human-readable connection status.
+--- @param connected boolean Whether this status represents a live connection;
+--- callers pass it explicitly so rewording a status can never silently flip
+--- the Connected variable.
+local function updateStatus(status, connected)
+  log:trace("updateStatus(%s, %s)", status, connected)
+  if type(connected) ~= "boolean" then
+    error(string.format("updateStatus(%s): connected must be an explicit boolean", tostring(status)), 2)
+  end
+  UpdateProperty("Driver Status", status)
+  values:update("Connected", connected, "BOOL")
+end
 
 local PROXY_BINDING = 5001
 local ESPHOME_BINDING = 5002
@@ -465,6 +481,7 @@ function OnDriverInit()
   log:trace("OnDriverInit()")
 
   -- Restore persisted state
+  values:restoreValues()
   bindings:restoreBindings()
 end
 
@@ -498,7 +515,7 @@ function OnDriverLateInit()
   end
 
   gInitialized = true
-  UpdateProperty("Driver Status", "Disconnected")
+  updateStatus("Disconnected", false)
   SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = false }, "NOTIFY")
   SendToProxy(ESPHOME_BINDING, "REFRESH_STATE", {}, "NOTIFY")
 end
@@ -894,7 +911,7 @@ function RFP.UPDATE_DISCONNECT(idBinding, strCommand, tParams, args)
   -- BINDING are persisted or proxy-driven and stay across reconnects.
   IS_SINGLE_SETPOINT = false
   USER_SERVICES_DISCOVERED = false
-  UpdateProperty("Driver Status", "Disconnected")
+  updateStatus("Disconnected", false)
   SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = false }, "NOTIFY")
 end
 
@@ -925,7 +942,7 @@ function RFP.UPDATE_STATE(idBinding, strCommand, tParams, args)
   STATE = state
 
   -- Always update connection status
-  UpdateProperty("Driver Status", "Connected")
+  updateStatus("Connected", true)
   SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = true }, "NOTIFY")
 
   -- Send capabilities on first state update

--- a/drivers/esphome_fan/driver.lua
+++ b/drivers/esphome_fan/driver.lua
@@ -15,9 +15,25 @@ require("drivers-common-public.global.timer")
 JSON = require("JSON")
 
 local log = require("lib.logging")
+local values = require("lib.values")
 local persist = require("lib.persist")
 
 local constants = require("constants")
+
+--- Update the Driver Status property and the Connected variable so
+--- Programming can react to connect/disconnect.
+--- @param status string The human-readable connection status.
+--- @param connected boolean Whether this status represents a live connection;
+--- callers pass it explicitly so rewording a status can never silently flip
+--- the Connected variable.
+local function updateStatus(status, connected)
+  log:trace("updateStatus(%s, %s)", status, connected)
+  if type(connected) ~= "boolean" then
+    error(string.format("updateStatus(%s): connected must be an explicit boolean", tostring(status)), 2)
+  end
+  UpdateProperty("Driver Status", status)
+  values:update("Connected", connected, "BOOL")
+end
 
 local ON_BINDING = 300
 local OFF_BINDING = 301
@@ -79,6 +95,9 @@ function OnDriverInit()
   log:setLogLevel(Properties["Log Level"])
   log:setLogMode(Properties["Log Mode"])
   log:trace("OnDriverInit()")
+
+  -- Restore persisted state
+  values:restoreValues()
 end
 
 function OnDriverLateInit()
@@ -100,7 +119,7 @@ function OnDriverLateInit()
   PRESET_SPEED = clampPresetSpeed(persist:get("PRESET_SPEED"))
 
   gInitialized = true
-  UpdateProperty("Driver Status", "Disconnected")
+  updateStatus("Disconnected", false)
   SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = false }, "NOTIFY")
   notifyPresetSpeed()
   SendToProxy(ESPHOME_BINDING, "REFRESH_STATE", {}, "NOTIFY")
@@ -357,7 +376,7 @@ function RFP.UPDATE_DISCONNECT(idBinding, strCommand, tParams, args)
   end
   ENTITY = nil
   STATE = nil
-  UpdateProperty("Driver Status", "Disconnected")
+  updateStatus("Disconnected", false)
   SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = false }, "NOTIFY")
 end
 
@@ -388,7 +407,7 @@ function RFP.UPDATE_STATE(idBinding, strCommand, tParams, args)
   STATE = state
 
   -- Always update connection status
-  UpdateProperty("Driver Status", "Connected")
+  updateStatus("Connected", true)
   SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = true }, "NOTIFY")
 
   -- Send ON/OFF notification

--- a/drivers/esphome_govee/driver.lua
+++ b/drivers/esphome_govee/driver.lua
@@ -19,6 +19,21 @@ local persist = require("lib.persist")
 local constants = require("constants")
 local Govee = require("esphome.ble.parsers.govee")
 
+--- Update the Driver Status property and the Connected variable so
+--- Programming can react to connect/disconnect.
+--- @param status string The human-readable connection status.
+--- @param connected boolean Whether this status represents a live connection;
+--- callers pass it explicitly so rewording a status can never silently flip
+--- the Connected variable.
+local function updateStatus(status, connected)
+  log:trace("updateStatus(%s, %s)", status, connected)
+  if type(connected) ~= "boolean" then
+    error(string.format("updateStatus(%s): connected must be an explicit boolean", tostring(status)), 2)
+  end
+  UpdateProperty("Driver Status", status)
+  values:update("Connected", connected, "BOOL")
+end
+
 --------------------------------------------------------------------------------
 -- Constants
 --------------------------------------------------------------------------------
@@ -488,7 +503,7 @@ local function processGoveeData(data, rssi)
   end
 
   UpdateProperty("Last Received", #summaryParts > 0 and table.concat(summaryParts, ", ") or "No data")
-  UpdateProperty("Driver Status", "Listening")
+  updateStatus("Listening", true)
 end
 
 --------------------------------------------------------------------------------
@@ -540,7 +555,7 @@ function OnDriverLateInit()
   end
 
   gInitialized = true
-  UpdateProperty("Driver Status", "Waiting for data")
+  updateStatus("Waiting for data", false)
 
   -- Request refresh from parent driver
   SendToProxy(ESPHOME_BINDING, "REFRESH_STATE", {}, "NOTIFY")
@@ -623,7 +638,7 @@ function RFP.CONNECTED_PASSIVE(idBinding, strCommand, tParams, args)
   -- Create events based on device model (only creates if not already present)
   createEventsForDevice(deviceType)
 
-  UpdateProperty("Driver Status", "Listening")
+  updateStatus("Listening", true)
 end
 
 --- Handle incoming BLE advertisement from parent driver
@@ -669,7 +684,7 @@ function RFP.DISCONNECTED(idBinding, strCommand, tParams, args)
   end
 
   log:info("Govee device disconnected")
-  UpdateProperty("Driver Status", "Waiting for data")
+  updateStatus("Waiting for data", false)
 end
 
 --------------------------------------------------------------------------------
@@ -681,9 +696,9 @@ OBC[ESPHOME_BINDING] = function(idBinding, strClass, bIsBound, otherDeviceId)
   persist:set("previousState", {})
 
   if bIsBound then
-    UpdateProperty("Driver Status", "Waiting for data")
+    updateStatus("Waiting for data", false)
   else
-    UpdateProperty("Driver Status", "Disconnected")
+    updateStatus("Disconnected", false)
   end
 end
 

--- a/drivers/esphome_light/driver.lua
+++ b/drivers/esphome_light/driver.lua
@@ -11,10 +11,26 @@ require("drivers-common-public.global.timer")
 JSON = require("JSON")
 
 local log = require("lib.logging")
+local values = require("lib.values")
 local persist = require("lib.persist")
 local constants = require("constants")
 
 local ESPHomeProtoSchema = require("esphome.proto_schema")
+
+--- Update the Driver Status property and the Connected variable so
+--- Programming can react to connect/disconnect.
+--- @param status string The human-readable connection status.
+--- @param connected boolean Whether this status represents a live connection;
+--- callers pass it explicitly so rewording a status can never silently flip
+--- the Connected variable.
+local function updateStatus(status, connected)
+  log:trace("updateStatus(%s, %s)", status, connected)
+  if type(connected) ~= "boolean" then
+    error(string.format("updateStatus(%s): connected must be an explicit boolean", tostring(status)), 2)
+  end
+  UpdateProperty("Driver Status", status)
+  values:update("Connected", connected, "BOOL")
+end
 
 ---------------------------------------------------------------------------
 -- Bindings
@@ -180,6 +196,9 @@ function OnDriverInit()
   log:setLogLevel(Properties["Log Level"])
   log:setLogMode(Properties["Log Mode"])
   log:trace("OnDriverInit()")
+
+  -- Restore persisted state
+  values:restoreValues()
 end
 
 function OnDriverLateInit()
@@ -198,7 +217,7 @@ function OnDriverLateInit()
   end
 
   gInitialized = true
-  UpdateProperty("Driver Status", "Disconnected")
+  updateStatus("Disconnected", false)
   SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = false }, "NOTIFY")
   SendToProxy(ESPHOME_BINDING, "REFRESH_STATE", {}, "NOTIFY")
 end
@@ -2308,7 +2327,7 @@ function RFP.UPDATE_DISCONNECT(idBinding, strCommand, tParams, args)
   mergedColorUntil = 0
   currentBrightnessPresetId = nil
   currentColorPresetId = nil
-  UpdateProperty("Driver Status", "Disconnected")
+  updateStatus("Disconnected", false)
   SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = false }, "NOTIFY")
   notifyBrightnessChanged(0)
 end
@@ -2337,7 +2356,7 @@ function RFP.UPDATE_STATE(idBinding, strCommand, tParams, args)
 
   -- Connection state must be sent BEFORE dynamic capabilities
   if not wasConnected then
-    UpdateProperty("Driver Status", "Connected")
+    updateStatus("Connected", true)
     SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = true }, "NOTIFY")
   end
 

--- a/drivers/esphome_lock/driver.lua
+++ b/drivers/esphome_lock/driver.lua
@@ -12,6 +12,22 @@ JSON = require("JSON")
 local ESPHomeProtoSchema = require("esphome.proto_schema")
 
 local log = require("lib.logging")
+local values = require("lib.values")
+
+--- Update the Driver Status property and the Connected variable so
+--- Programming can react to connect/disconnect.
+--- @param status string The human-readable connection status.
+--- @param connected boolean Whether this status represents a live connection;
+--- callers pass it explicitly so rewording a status can never silently flip
+--- the Connected variable.
+local function updateStatus(status, connected)
+  log:trace("updateStatus(%s, %s)", status, connected)
+  if type(connected) ~= "boolean" then
+    error(string.format("updateStatus(%s): connected must be an explicit boolean", tostring(status)), 2)
+  end
+  UpdateProperty("Driver Status", status)
+  values:update("Connected", connected, "BOOL")
+end
 
 local PROXY_BINDING = 5001
 local ESPHOME_BINDING = 5002
@@ -31,6 +47,9 @@ function OnDriverInit()
   log:setLogLevel(Properties["Log Level"])
   log:setLogMode(Properties["Log Mode"])
   log:trace("OnDriverInit()")
+
+  -- Restore persisted state
+  values:restoreValues()
 end
 
 function OnDriverLateInit()
@@ -48,7 +67,7 @@ function OnDriverLateInit()
     end
   end
   gInitialized = true
-  UpdateProperty("Driver Status", "Disconnected")
+  updateStatus("Disconnected", false)
   SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = false }, "NOTIFY")
   SendToProxy(ESPHOME_BINDING, "REFRESH_STATE", {}, "NOTIFY")
 end
@@ -220,7 +239,7 @@ function RFP.UPDATE_DISCONNECT(idBinding, strCommand, tParams, args)
   end
   ENTITY = nil
   STATE = nil
-  UpdateProperty("Driver Status", "Disconnected")
+  updateStatus("Disconnected", false)
   SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = false }, "NOTIFY")
 end
 
@@ -249,7 +268,7 @@ function RFP.UPDATE_STATE(idBinding, strCommand, tParams, args)
   local newStatus = convertLockStateToStatus(Select(state, "state"))
 
   if oldStatus ~= newStatus then
-    UpdateProperty("Driver Status", "Connected")
+    updateStatus("Connected", true)
     SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = true }, "NOTIFY")
     log:debug("State changed from %s -> %s", oldStatus, newStatus)
     SendToProxy(PROXY_BINDING, "LOCK_STATUS_CHANGED", { LOCK_STATUS = newStatus }, "NOTIFY")

--- a/drivers/esphome_switchbot/driver.lua
+++ b/drivers/esphome_switchbot/driver.lua
@@ -22,6 +22,21 @@ local UUID = require("esphome.ble.uuid")
 local SwitchBot = require("esphome.ble.parsers.switchbot")
 local http = require("lib.http")
 
+--- Update the Driver Status property and the Connected variable so
+--- Programming can react to connect/disconnect.
+--- @param status string The human-readable connection status.
+--- @param connected boolean Whether this status represents a live connection;
+--- callers pass it explicitly so rewording a status can never silently flip
+--- the Connected variable.
+local function updateStatus(status, connected)
+  log:trace("updateStatus(%s, %s)", status, connected)
+  if type(connected) ~= "boolean" then
+    error(string.format("updateStatus(%s): connected must be an explicit boolean", tostring(status)), 2)
+  end
+  UpdateProperty("Driver Status", status)
+  values:update("Connected", connected, "BOOL")
+end
+
 --------------------------------------------------------------------------------
 -- Constants
 --------------------------------------------------------------------------------
@@ -1413,7 +1428,7 @@ local function initiateCommand(cmd, channel, isOn)
     isOn = isOn,
   }
 
-  UpdateProperty("Driver Status", "Busy")
+  updateStatus("Busy", true)
   requestConnection()
 end
 
@@ -1609,7 +1624,7 @@ local function initializeForDeviceType(deviceTypeStr)
   else
     -- Unknown device type
     log:warn("Unknown device category for: %s", deviceTypeStr)
-    UpdateProperty("Driver Status", "Unknown device type: " .. (deviceTypeStr or "nil"))
+    updateStatus("Unknown device type: " .. (deviceTypeStr or "nil"), false)
     hideBotProperties()
     hideSwitchProperties()
     hideSensorProperties()
@@ -1706,7 +1721,7 @@ local function processSwitchBotData(data, rssi)
       end
     end
     UpdateProperty("Last Received", #summaryParts > 0 and table.concat(summaryParts, ", ") or "No data")
-    UpdateProperty("Driver Status", "Listening")
+    updateStatus("Listening", true)
     return
   end
 
@@ -1739,7 +1754,7 @@ local function processSwitchBotData(data, rssi)
     end
 
     UpdateProperty("Last Received", #summaryParts > 0 and table.concat(summaryParts, ", ") or "No data")
-    UpdateProperty("Driver Status", "Listening")
+    updateStatus("Listening", true)
     return
   end
 
@@ -1856,7 +1871,7 @@ local function processSwitchBotData(data, rssi)
     end
 
     UpdateProperty("Last Received", #summaryParts > 0 and table.concat(summaryParts, ", ") or "No data")
-    UpdateProperty("Driver Status", "Listening")
+    updateStatus("Listening", true)
   end
 end
 
@@ -1946,7 +1961,7 @@ function OnDriverLateInit()
   end
 
   gInitialized = true
-  UpdateProperty("Driver Status", "Waiting for data")
+  updateStatus("Waiting for data", false)
 
   -- Request refresh from parent driver
   SendToProxy(ESPHOME_BINDING, "REFRESH_STATE", {}, "NOTIFY")
@@ -2376,12 +2391,12 @@ function RFP.CONNECTED(idBinding, strCommand, tParams, args)
           executePendingCommand()
         end
       else
-        UpdateProperty("Driver Status", "Error: Missing characteristics")
+        updateStatus("Error: Missing characteristics", false)
       end
     end
   else
     log:error("No services provided in CONNECTED message")
-    UpdateProperty("Driver Status", "Error: Missing services")
+    updateStatus("Error: Missing services", false)
   end
 end
 
@@ -2411,7 +2426,7 @@ function RFP.CONNECTED_PASSIVE(idBinding, strCommand, tParams, args)
     initializeForDeviceType(devType)
   end
 
-  UpdateProperty("Driver Status", "Listening")
+  updateStatus("Listening", true)
 end
 
 --- Handle incoming BLE advertisement from parent driver
@@ -2473,7 +2488,7 @@ function RFP.DISCONNECTED(idBinding, strCommand, tParams, args)
   resetConnectionState()
 
   -- If we just received a response acknowledging our disconnect, then we are still listening
-  UpdateProperty("Driver Status", "Listening")
+  updateStatus("Listening", true)
 end
 
 --- Handle connection failure notification from main driver
@@ -2487,7 +2502,7 @@ function RFP.CONNECTION_FAILED(idBinding, strCommand, tParams, args)
   log:error("Connection failed: %s", error)
 
   resetConnectionState()
-  UpdateProperty("Driver Status", "Connection Failed: " .. error)
+  updateStatus("Connection Failed: " .. error, false)
 end
 
 --------------------------------------------------------------------------------
@@ -2506,7 +2521,7 @@ function RFP.GATT_WRITE_RESPONSE(idBinding, strCommand, tParams, args)
 
   if success then
     log:debug("Write command successful")
-    UpdateProperty("Driver Status", "Busy")
+    updateStatus("Busy", true)
     updateLastSeen()
 
     -- Bot press mode: revert to OPENED
@@ -2658,9 +2673,9 @@ OBC[ESPHOME_BINDING] = function(idBinding, strClass, bIsBound, otherDeviceId)
   clearNotifiedState()
 
   if bIsBound then
-    UpdateProperty("Driver Status", "Waiting for data")
+    updateStatus("Waiting for data", false)
   else
-    UpdateProperty("Driver Status", "Disconnected")
+    updateStatus("Disconnected", false)
   end
 end
 

--- a/drivers/esphome_yale/driver.lua
+++ b/drivers/esphome_yale/driver.lua
@@ -23,6 +23,21 @@ local UUID = require("esphome.ble.uuid")
 local yale_protocol = require("esphome.ble.yale_protocol")
 local http = require("lib.http")
 
+--- Update the Driver Status property and the Connected variable so
+--- Programming can react to connect/disconnect.
+--- @param status string The human-readable connection status.
+--- @param connected boolean Whether this status represents a live connection;
+--- callers pass it explicitly so rewording a status can never silently flip
+--- the Connected variable.
+local function updateStatus(status, connected)
+  log:trace("updateStatus(%s, %s)", status, connected)
+  if type(connected) ~= "boolean" then
+    error(string.format("updateStatus(%s): connected must be an explicit boolean", tostring(status)), 2)
+  end
+  UpdateProperty("Driver Status", status)
+  values:update("Connected", connected, "BOOL")
+end
+
 --------------------------------------------------------------------------------
 -- Constants
 --------------------------------------------------------------------------------
@@ -138,6 +153,14 @@ local BASE_RECONNECT_MS = 5000
 --- Whether initial status query has been triggered (for Poll mode first-advertisement)
 --- @type boolean
 local initialStatusTriggered = false
+
+--- Whether the next DISCONNECTED from the coordinator is one we asked for.
+--- Armed only at the healthy end of a Poll-mode cycle (status chain complete),
+--- never on the error paths that also route through the polite disconnect, so
+--- a failed handshake can never report Connected; cleared when a new handshake
+--- starts, on mode change, and on driver reset.
+--- @type boolean
+local expectedDisconnect = false
 
 --- August cloud session token (for key fetching)
 --- @type string|nil
@@ -315,7 +338,7 @@ end
 --- and detect state changes from unsolicited notifications.
 local function startKeepalive()
   log:info("Persistent connection established - starting keepalive")
-  UpdateProperty("Driver Status", "Connected")
+  updateStatus("Connected", true)
   CancelTimer("DisconnectDelay")
   SetTimer("Keepalive", KEEPALIVE_INTERVAL_MS, function()
     if handshakeState == HANDSHAKE_STATE.COMPLETE and session and session:isReady() then
@@ -330,10 +353,12 @@ end
 
 --- Schedule next poll cycle (Poll mode only).
 --- Sets a one-shot timer that connects, queries status, then disconnects.
-local function schedulePoll()
+--- @param connected boolean? Whether the cycle that just ended was healthy;
+--- drives the Connected variable across the wait (defaults to false).
+local function schedulePoll(connected)
   local interval = tointeger(Properties["Polling Interval"]) or 60
   log:info("Scheduling next poll in %d seconds", interval)
-  UpdateProperty("Driver Status", string.format("Listening (next poll in %ds)", interval))
+  updateStatus(string.format("Listening (next poll in %ds)", interval), connected == true)
   CancelTimer("PollCycle")
   SetTimer("PollCycle", interval * 1000, function()
     log:info("Poll timer fired - querying status")
@@ -348,7 +373,9 @@ local function onStatusChainComplete()
   if connectionMode == CONNECTION_MODE.PERSISTENT then
     startKeepalive()
   else
-    -- Poll mode: disconnect immediately after query
+    -- Poll mode: disconnect immediately after query. This is the only healthy
+    -- terminus, so it alone marks the coming disconnect as expected.
+    expectedDisconnect = true
     sendCleanDisconnect()
   end
 end
@@ -373,6 +400,7 @@ local function setConnectionMode(newMode)
   -- Reset state
   reconnectAttempts = 0
   initialStatusTriggered = false
+  expectedDisconnect = false
 
   -- Set new mode
   connectionMode = newMode
@@ -384,7 +412,7 @@ local function setConnectionMode(newMode)
     C4:SetPropertyAttribs("Polling Interval", constants.HIDE_PROPERTY)
   end
 
-  UpdateProperty("Driver Status", "Listening")
+  updateStatus("Listening", false)
 end
 
 --- Subscribe to GATT notifications on a handle
@@ -450,28 +478,31 @@ end
 local function scheduleRecovery(status, savedCommand)
   if connectionMode == CONNECTION_MODE.PERSISTENT then
     if not isAuthConfigured() then
-      UpdateProperty("Driver Status", "Listening")
+      updateStatus("Listening", false)
       return
     end
     reconnectAttempts = reconnectAttempts + 1
     if reconnectAttempts > MAX_RECONNECT_ATTEMPTS then
       log:warn("Max reconnect attempts (%d) reached: %s", MAX_RECONNECT_ATTEMPTS, status)
-      UpdateProperty("Driver Status", "Listening (reconnect failed)")
+      updateStatus("Listening (reconnect failed)", false)
       reconnectAttempts = 0
       return
     end
     local delay = BASE_RECONNECT_MS * (2 ^ (reconnectAttempts - 1))
     log:info("Retrying in %ds (attempt %d/%d): %s", delay / 1000, reconnectAttempts, MAX_RECONNECT_ATTEMPTS, status)
-    UpdateProperty("Driver Status", string.format("Reconnecting (%d/%d)", reconnectAttempts, MAX_RECONNECT_ATTEMPTS))
+    updateStatus(string.format("Reconnecting (%d/%d)", reconnectAttempts, MAX_RECONNECT_ATTEMPTS), false)
     local retryCommand = savedCommand or "status"
     SetTimer("Reconnect", delay, function()
       initiateCommand(retryCommand)
     end)
   elseif connectionMode == CONNECTION_MODE.POLL then
-    UpdateProperty("Driver Status", status)
+    -- Only failures land here; healthy cycles bypass this path via
+    -- expectedDisconnect in RFP.DISCONNECTED. The failure text is superseded
+    -- by the schedule text in the same tick — Connected = false carries the
+    -- signal.
     schedulePoll()
   else
-    UpdateProperty("Driver Status", status)
+    updateStatus(status, false)
   end
 end
 
@@ -585,11 +616,12 @@ end
 --- Start the Yale BLE handshake
 local function startHandshake()
   log:info("Starting Yale BLE handshake")
+  expectedDisconnect = false
 
   local offlineKey = getOfflineKey()
   if not offlineKey then
     log:error("Cannot start handshake: offline key not configured")
-    UpdateProperty("Driver Status", "Error: Offline key required")
+    updateStatus("Error: Offline key required", false)
     requestDisconnect()
     return
   end
@@ -754,7 +786,7 @@ local function handleInitResponse(data)
   CancelTimer("HandshakeTimeout")
   handshakeState = HANDSHAKE_STATE.COMPLETE
   reconnectAttempts = 0
-  UpdateProperty("Driver Status", "Connected")
+  updateStatus("Connected", true)
   SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = true }, "NOTIFY")
 
   -- Per yalexs-ble: subscribe regular read AFTER handshake completes
@@ -1250,7 +1282,7 @@ function OnDriverLateInit()
     end
   end
   gInitialized = true
-  UpdateProperty("Driver Status", "Disconnected")
+  updateStatus("Disconnected", false)
   SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = false }, "NOTIFY")
 
   -- Restore lock status from persisted property
@@ -1345,9 +1377,10 @@ function OPC.Polling_Interval(propertyValue)
   if not gInitialized then
     return
   end
-  -- Reschedule poll timer if currently in Poll mode and idle
+  -- Reschedule poll timer if currently in Poll mode and idle, carrying the
+  -- current Connected value so an interval edit cannot flap a healthy lock
   if connectionMode == CONNECTION_MODE.POLL and handshakeState == HANDSHAKE_STATE.IDLE then
-    schedulePoll()
+    schedulePoll(Select(values:getValue("Connected"), "value") == true)
   end
 end
 
@@ -1457,12 +1490,12 @@ function RFP.CONNECTED(idBinding, strCommand, tParams, args)
         regularReadSubscribed = false
         subscribeNotifications(cSR)
       else
-        UpdateProperty("Driver Status", "Error: Missing characteristics")
+        updateStatus("Error: Missing characteristics", false)
       end
     end
   else
     log:error("No services provided in CONNECTED message")
-    UpdateProperty("Driver Status", "Error: Missing services")
+    updateStatus("Error: Missing services", false)
   end
 end
 
@@ -1479,7 +1512,7 @@ function RFP.BLE_ADVERTISEMENT(idBinding, strCommand, tParams, args)
   -- Go online on first advertisement if still disconnected
   local driverStatus = Properties["Driver Status"]
   if driverStatus == "Disconnected" then
-    UpdateProperty("Driver Status", "Listening")
+    updateStatus("Listening", false)
     SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = true }, "NOTIFY")
     if currentLockStatus then
       SendToProxy(PROXY_BINDING, "LOCK_STATUS_CHANGED", { LOCK_STATUS = currentLockStatus }, "NOTIFY")
@@ -1563,6 +1596,16 @@ function RFP.DISCONNECTED(idBinding, strCommand, tParams, args)
     savedCommand = nil
   end
 
+  -- A clean disconnect we asked for is the healthy end of a poll cycle;
+  -- route it to the next poll rather than the failure path.
+  if expectedDisconnect and connectionMode == CONNECTION_MODE.POLL then
+    expectedDisconnect = false
+    resetConnectionState()
+    schedulePoll(true)
+    return
+  end
+  expectedDisconnect = false
+
   resetConnectionState()
   scheduleRecovery("Disconnected: " .. reason, savedCommand)
 end
@@ -1633,7 +1676,7 @@ function RFP.GATT_NOTIFY_SUBSCRIBED(idBinding, strCommand, tParams, args)
       startHandshake()
     else
       log:warn("Authentication not configured")
-      UpdateProperty("Driver Status", "Error: Offline key required")
+      updateStatus("Error: Offline key required", false)
       requestDisconnect()
     end
   elseif handle == readHandle then
@@ -1703,9 +1746,9 @@ OBC[ESPHOME_BINDING] = function(idBinding, strClass, bIsBound, otherDeviceId)
   resetConnectionState(true)
 
   if bIsBound then
-    UpdateProperty("Driver Status", "Waiting for data")
+    updateStatus("Waiting for data", false)
   else
-    UpdateProperty("Driver Status", "Disconnected")
+    updateStatus("Disconnected", false)
   end
 end
 
@@ -1765,9 +1808,9 @@ function EC.Reset_Driver(params)
   log:print("Resetting driver to initial state")
 
   bindings:reset()
-  values:reset()
   resetConnectionState(true)
   initialStatusTriggered = false
+  expectedDisconnect = false
   doorSenseConfigured = nil
   -- Clear the in-memory notify memo so a recreated contact binding receives
   -- the next door status
@@ -1781,7 +1824,10 @@ function EC.Reset_Driver(params)
     C4:SetPropertyAttribs("Polling Interval", constants.SHOW_PROPERTY)
   end
 
-  UpdateProperty("Driver Status", "Disconnected")
+  updateStatus("Disconnected", false)
+  -- Delete the variables after the final status write so Reset Driver does not
+  -- immediately recreate the Connected variable it just removed
+  values:reset()
   UpdateProperty("Lock Status", "Unknown")
   UpdateProperty("Door Status", "")
   C4:SetPropertyAttribs("Door Status", constants.HIDE_PROPERTY)


### PR DESCRIPTION
Fixes [DRV-44](https://youtrack.dmiller.me/issue/DRV-44), taking the ticket's recommended per-driver-helper first pass.

Programming can now react to connect/disconnect: every driver with a Driver Status gets a `Connected` BOOL variable (true for `Connected` and `Listening` — the union across driver lifecycles, per the ticket's open question 2; `Waiting for data` deliberately counts as not connected). The DRV-42 BOOL dependency the ticket flagged shipped in v20260711, so the BOOL is fully usable.

## Shape

- One `updateStatus(status, connected)` helper per driver (main driver's existing helper extended in place, preserving its empty→"Unknown" normalization). Every one of the ~70 former `UpdateProperty("Driver Status", ...)` call sites routes through it with an explicit `connected` boolean — there is no status-string lookup; the helper hard-errors if a caller omits the flag, so rewording a status can never silently flip the variable.
- The single pre-init `"Initializing"` guard in each sub-driver's `OPC.Driver_Status` stays a direct property write: values aren't restored at that point and the transient isn't a meaningful programmable state — the variables pick up at the first real status seconds later.
- lock/climate/light/fan didn't use the values lib; they gain the require plus `values:restoreValues()` in `OnDriverInit` matching the other drivers.
- `Reset_Driver`'s existing `values:reset()` removes the variable (acceptance criterion 6) on the six drivers that have a Reset Driver action; yale defers the reset until after its final status write so the handler does not recreate the variable it just deleted.

Deliberately deferred, matching the ticket's own scoping: a shared `src/lib` helper (factor later if the duplication accumulates), a separate `Bluetooth Proxy Connected` BOOL, and transition-edge C4 events.

## Verification

`luajit` on all ten drivers, stylua/mdformat idempotent, full package build exits 0. Audited that the only remaining direct literal `Driver Status` writes are the eight pre-init guards plus each helper's internal write (the four post-reset property-restore loops also touch it via a loop variable, immediately after `values:reset()` has deleted the variable, so no desync is possible), and that formatted statuses (`Reconnecting (%d/%d)`, `Listening (next poll in %ds)`) converted intact.


