### PR TITLE
DRV-69: Add konnected Smart Garage Door Opener to Verified Devices docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,13 @@ monitoring and control of ESPHome devices directly from your Control4 system.
 This driver will generically work with any ESPHome device, but we have tested
 extensively with the following devices:
 
-- [ratgdo](https://ratcloud.llc) -
-  [Garage Door Configuration Guide](#garage-door-configuration-guide)
+- [ratgdo](https://ratcloud.llc)
 - konnected Smart Garage Door Opener -
   [blaQ](https://konnected.io/products/smart-garage-door-opener-blaq-myq-alternative)
-  / [White](https://konnected.io/products/smart-garage-door-opener) -
-  [Garage Door Configuration Guide](#garage-door-configuration-guide)
+  / [White](https://konnected.io/products/smart-garage-door-opener)
+
+Both are relay-based garage door controllers - see the
+[Garage Door Configuration Guide](#garage-door-configuration-guide).
 
 If you try this driver on a product listed above, and it works, let us know!
 
@@ -546,10 +547,16 @@ bindings are created separately from the entity bindings above:
 
 # <span style="color:#17BCF2">Garage Door Configuration Guide</span>
 
-This guide provides instructions for configuring the ESPHome driver to work with
-ratgdo devices for garage door control via relays in Control4 Composer Pro.
-Other relay-based garage door controllers, such as konnected's Smart Garage Door
-Opener, should be configured similarly.
+This guide provides instructions for configuring the ESPHome driver for garage
+door control via relays in Control4 Composer Pro. It applies to any ESPHome
+device that exposes a cover entity, including ratgdo and konnected's Smart
+Garage Door Opener.
+
+The driver names the relay and contact bindings after the cover entity, so the
+labels shown in Composer Pro depend on the device. ratgdo names its cover
+"Door", giving "Open Door" and "Door Closed". konnected defaults to "Garage
+Door", giving "Open Garage Door" and "Garage Door Closed". Substitute your
+device's cover name throughout this guide.
 
 ## Add Relay Controller Driver
 
@@ -560,27 +567,25 @@ Pro.
 
 ## Relay Controller Properties
 
-The ratgdo device exposes a "Cover" entity in ESPHome, which maps to the relay
+The device exposes a "Cover" entity in ESPHome, which maps to the relay
 controller functionality in Control4.
 
 ### Number of Relays
 
-The ratgdo device uses a multi-relay configuration to control the garage door.
-In Composer Pro, you should configure the relay settings as follows:
+The driver creates separate relays for opening and closing the garage door. In
+Composer Pro, you should configure the relay settings as follows:
 
 - Set to **2 Relays** (Open/Close) or **3 Relays** (Open/Close/Stop)
-  - The ratgdo device uses separate commands for opening and closing the garage
-    door
-  - If your ratgdo firmware supports the "stop" command, configure for 3 relays
-    to enable the stop functionality. If you are not sure, you can look at the
-    ratgdo connections in Composer Pro to see if the "Stop Door" relay is
-    available.
+  - The driver creates separate relays for opening and closing the garage door
+  - The stop relay is only created when the device reports support for it. If
+    you are not sure, look at the connections in Composer Pro to see if the
+    "Stop" relay is available, and configure for 3 relays if it is.
 
 ### Relay Configuration
 
 - Set to **Pulse**
-  - ratgdo uses momentary pulses to trigger the garage door opener, similar to a
-    wall button press
+  - These devices use momentary pulses to trigger the garage door opener,
+    similar to a wall button press
 
 ### Pulse Time
 
@@ -611,14 +616,17 @@ Pro:
 
 ### Relays
 
-- **Open**: Connect to the ratgdo's "Open Door" relay
-- **Close**: Connect to the ratgdo's "Close Door" relay
-- **Stop**: Connect to the ratgdo's "Stop Door" relay, if available
+Where `{cover}` is the name of the device's cover entity ("Door" on ratgdo,
+"Garage Door" on konnected):
+
+- **Open**: Connect to the "Open {cover}" relay
+- **Close**: Connect to the "Close {cover}" relay
+- **Stop**: Connect to the "Stop {cover}" relay, if available
 
 ### Contact Sensors
 
-- **Closed Contact**: Connect to the ratgdo's "Door Closed" contact
-- **Opened Contact**: Connect to the ratgdo's "Door Open" contact
+- **Closed Contact**: Connect to the "{cover} Closed" contact
+- **Opened Contact**: Connect to the "{cover} Open" contact
 
 ### Example Connections
 
@@ -646,14 +654,16 @@ Using the "Still Open Time" property from the relay controller driver:
 
 ## Additional Entities
 
-Depending on your ratgdo device, firmware, and its capabilities, there may be
+Depending on your device, firmware, and its capabilities, there may be
 additional entities exposed by the ESPHome driver. These can come as additional
 connections or driver variables.
 
-Please refer to ratgdo's documentation for more information on specific
+Please refer to your device's documentation for more information on specific
 entities:
 
-https://ratgdo.github.io/esphome-ratgdo/webui_documentation.html
+- ratgdo: https://ratgdo.github.io/esphome-ratgdo/webui_documentation.html
+- konnected:
+  https://support.konnected.io/esphome-on-the-konnected-garage-door-opener
 
 # <span style="color:#17BCF2">Bluetooth Proxy Configuration Guide</span>
 

--- a/README.md
+++ b/README.md
@@ -553,10 +553,9 @@ device that exposes a cover entity, including ratgdo and konnected's Smart
 Garage Door Opener.
 
 The driver names the relay and contact bindings after the cover entity, so the
-labels shown in Composer Pro depend on the device. ratgdo names its cover
-"Door", giving "Open Door" and "Door Closed". konnected defaults to "Garage
-Door", giving "Open Garage Door" and "Garage Door Closed". Substitute your
-device's cover name throughout this guide.
+labels in Composer Pro depend on the device. ratgdo names its cover "Door", so
+you will see "Open Door" and "Door Closed". konnected defaults to "Garage Door".
+Substitute your device's cover name throughout this guide.
 
 ## Add Relay Controller Driver
 
@@ -576,7 +575,6 @@ The driver creates separate relays for opening and closing the garage door. In
 Composer Pro, you should configure the relay settings as follows:
 
 - Set to **2 Relays** (Open/Close) or **3 Relays** (Open/Close/Stop)
-  - The driver creates separate relays for opening and closing the garage door
   - The stop relay is only created when the device reports support for it. If
     you are not sure, look at the connections in Composer Pro to see if the
     "Stop" relay is available, and configure for 3 relays if it is.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ monitoring and control of ESPHome devices directly from your Control4 system.
 
 - [Configuration Guides](#configuration-guides)
 
-  - [ratgdo Configuration Guide](#ratgdo-configuration-guide)
+  - [Garage Door Configuration Guide](#garage-door-configuration-guide)
   - [Bluetooth Proxy Configuration Guide](#bluetooth-proxy-configuration-guide)
 
 - [Support](#support)
@@ -52,8 +52,6 @@ monitoring and control of ESPHome devices directly from your Control4 system.
 - [Changelog](#changelog)
 
 </div>
-
-<div style="page-break-after: always"></div>
 
 # <span style="color:#17BCF2">System Requirements</span>
 
@@ -75,7 +73,11 @@ This driver will generically work with any ESPHome device, but we have tested
 extensively with the following devices:
 
 - [ratgdo](https://ratcloud.llc) -
-  [Configuration Guide](#ratgdo-configuration-guide)
+  [Garage Door Configuration Guide](#garage-door-configuration-guide)
+- konnected Smart Garage Door Opener -
+  [blaQ](https://konnected.io/products/smart-garage-door-opener-blaq-myq-alternative)
+  / [White](https://konnected.io/products/smart-garage-door-opener) -
+  [Garage Door Configuration Guide](#garage-door-configuration-guide)
 
 If you try this driver on a product listed above, and it works, let us know!
 
@@ -92,8 +94,6 @@ types through sub-drivers:
 | Yale/August | ESPHome Yale      | Yale and August smart locks                          |
 
 See the individual sub-driver documentation for device-specific details.
-
-<div style="page-break-after: always"></div>
 
 ## Supported ESPHome Entities
 
@@ -136,8 +136,6 @@ See the individual sub-driver documentation for device-specific details.
 > \* Voice Assistant requires a speech-to-text and intent processing pipeline
 > (e.g. Home Assistant Assist). Control4 does not natively provide voice intent
 > handling, so this entity type is not supported.
-
-<div style="page-break-after: always"></div>
 
 # <span style="color:#17BCF2">Installer Setup</span>
 
@@ -544,14 +542,14 @@ bindings are created separately from the entity bindings above:
 > ESPHome button entities. The Select and Option parameters are dynamic lists
 > populated with discovered ESPHome select entities and their available options.
 
-<div style="page-break-after: always"></div>
-
 # <span style="display:none">Configuration Guides</span>
 
-# <span style="color:#17BCF2">ratgdo Configuration Guide</span>
+# <span style="color:#17BCF2">Garage Door Configuration Guide</span>
 
 This guide provides instructions for configuring the ESPHome driver to work with
 ratgdo devices for garage door control via relays in Control4 Composer Pro.
+Other relay-based garage door controllers, such as konnected's Smart Garage Door
+Opener, should be configured similarly.
 
 ## Add Relay Controller Driver
 
@@ -656,8 +654,6 @@ Please refer to ratgdo's documentation for more information on specific
 entities:
 
 https://ratgdo.github.io/esphome-ratgdo/webui_documentation.html
-
-<div style="page-break-after: always"></div>
 
 # <span style="color:#17BCF2">Bluetooth Proxy Configuration Guide</span>
 
@@ -825,8 +821,6 @@ For optimal BLE reception:
 | Through 1-2 walls    | 5-10 meters (15-30 ft)  |
 | Concrete/brick walls | 3-5 meters (10-15 ft)   |
 
-<div style="page-break-after: always"></div>
-
 ## Bluetooth Coordinator Setup
 
 For advanced setups with **multiple ESPHome Bluetooth proxies**, use the
@@ -873,8 +867,6 @@ When an ESPHome driver is connected to the coordinator:
 See the **ESPHome Bluetooth Coordinator** driver documentation for full details
 on presence tracking settings and events.
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">Support</span>
 
 If you have any questions or issues integrating this driver with Control4, you
@@ -883,8 +875,6 @@ can file an issue on GitHub:
 https://github.com/finitelabs/control4-esphome/issues/new
 
 <a href="https://www.buymeacoffee.com/derek.miller" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
-
-<div style="page-break-after: always"></div>
 
 # <span style="color:#17BCF2">Changelog</span>
 

--- a/drivers/esphome/www/documentation/index.md
+++ b/drivers/esphome/www/documentation/index.md
@@ -92,6 +92,9 @@ extensively with the following devices:
 
 - [ratgdo](https://ratcloud.llc) -
   [Configuration Guide](#ratgdo-configuration-guide)
+- konnected Smart Garage Door Opener -
+  [blaQ](https://konnected.io/products/smart-garage-door-opener-blaq-myq-alternative)
+  / [White](https://konnected.io/products/smart-garage-door-opener)
 
 If you try this driver on a product listed above, and it works, let us know!
 

--- a/drivers/esphome/www/documentation/index.md
+++ b/drivers/esphome/www/documentation/index.md
@@ -69,8 +69,6 @@ monitoring and control of ESPHome devices directly from your Control4 system.
 
 </div>
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">System Requirements</span>
 
 - Control4 OS 3.3+
@@ -113,8 +111,6 @@ types through sub-drivers:
 
 See the individual sub-driver documentation for device-specific details.
 
-<div style="page-break-after: always"></div>
-
 ## Supported ESPHome Entities
 
 <div style="font-size: small">
@@ -156,8 +152,6 @@ See the individual sub-driver documentation for device-specific details.
 > \* Voice Assistant requires a speech-to-text and intent processing pipeline
 > (e.g. Home Assistant Assist). Control4 does not natively provide voice intent
 > handling, so this entity type is not supported.
-
-<div style="page-break-after: always"></div>
 
 # <span style="color:#17BCF2">Installer Setup</span>
 
@@ -648,8 +642,6 @@ bindings are created separately from the entity bindings above:
 > ESPHome button entities. The Select and Option parameters are dynamic lists
 > populated with discovered ESPHome select entities and their available options.
 
-<div style="page-break-after: always"></div>
-
 # <span style="display:none">Configuration Guides</span>
 
 # <span style="color:#17BCF2">Garage Door Configuration Guide</span>
@@ -762,8 +754,6 @@ Please refer to ratgdo's documentation for more information on specific
 entities:
 
 https://ratgdo.github.io/esphome-ratgdo/webui_documentation.html
-
-<div style="page-break-after: always"></div>
 
 # <span style="color:#17BCF2">Bluetooth Proxy Configuration Guide</span>
 
@@ -931,8 +921,6 @@ For optimal BLE reception:
 | Through 1-2 walls    | 5-10 meters (15-30 ft)  |
 | Concrete/brick walls | 3-5 meters (10-15 ft)   |
 
-<div style="page-break-after: always"></div>
-
 ## Bluetooth Coordinator Setup
 
 For advanced setups with **multiple ESPHome Bluetooth proxies**, use the
@@ -979,8 +967,6 @@ When an ESPHome driver is connected to the coordinator:
 See the **ESPHome Bluetooth Coordinator** driver documentation for full details
 on presence tracking settings and events.
 
-<div style="page-break-after: always"></div>
-
 <!-- #ifdef DRIVERCENTRAL -->
 
 # <span style="color:#17BCF2">Developer Information</span>
@@ -1021,7 +1007,5 @@ https://github.com/finitelabs/control4-esphome/issues/new
 <a href="https://www.buymeacoffee.com/derek.miller" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 
 <!-- #endif -->
-
-<div style="page-break-after: always"></div>
 
 <!-- #embed-changelog -->

--- a/drivers/esphome/www/documentation/index.md
+++ b/drivers/esphome/www/documentation/index.md
@@ -57,7 +57,7 @@ monitoring and control of ESPHome devices directly from your Control4 system.
     - [Driver Actions](#driver-actions)
   - [Programming Reference](#programming-reference)
 - [Configuration Guides](#configuration-guides)
-  - [ratgdo Configuration Guide](#ratgdo-configuration-guide)
+  - [Garage Door Configuration Guide](#garage-door-configuration-guide)
   - [Bluetooth Proxy Configuration Guide](#bluetooth-proxy-configuration-guide)
   <!-- #ifdef DRIVERCENTRAL -->
 - [Developer Information](#developer-information)
@@ -91,10 +91,11 @@ This driver will generically work with any ESPHome device, but we have tested
 extensively with the following devices:
 
 - [ratgdo](https://ratcloud.llc) -
-  [Configuration Guide](#ratgdo-configuration-guide)
+  [Garage Door Configuration Guide](#garage-door-configuration-guide)
 - konnected Smart Garage Door Opener -
   [blaQ](https://konnected.io/products/smart-garage-door-opener-blaq-myq-alternative)
-  / [White](https://konnected.io/products/smart-garage-door-opener)
+  / [White](https://konnected.io/products/smart-garage-door-opener) -
+  [Garage Door Configuration Guide](#garage-door-configuration-guide)
 
 If you try this driver on a product listed above, and it works, let us know!
 
@@ -651,10 +652,12 @@ bindings are created separately from the entity bindings above:
 
 # <span style="display:none">Configuration Guides</span>
 
-# <span style="color:#17BCF2">ratgdo Configuration Guide</span>
+# <span style="color:#17BCF2">Garage Door Configuration Guide</span>
 
 This guide provides instructions for configuring the ESPHome driver to work with
 ratgdo devices for garage door control via relays in Control4 Composer Pro.
+Other relay-based garage door controllers, such as konnected's Smart Garage Door
+Opener, should be configured similarly.
 
 ## Add Relay Controller Driver
 

--- a/drivers/esphome/www/documentation/index.md
+++ b/drivers/esphome/www/documentation/index.md
@@ -653,10 +653,9 @@ device that exposes a cover entity, including ratgdo and konnected's Smart
 Garage Door Opener.
 
 The driver names the relay and contact bindings after the cover entity, so the
-labels shown in Composer Pro depend on the device. ratgdo names its cover
-"Door", giving "Open Door" and "Door Closed". konnected defaults to "Garage
-Door", giving "Open Garage Door" and "Garage Door Closed". Substitute your
-device's cover name throughout this guide.
+labels in Composer Pro depend on the device. ratgdo names its cover "Door", so
+you will see "Open Door" and "Door Closed". konnected defaults to "Garage Door".
+Substitute your device's cover name throughout this guide.
 
 ## Add Relay Controller Driver
 
@@ -676,7 +675,6 @@ The driver creates separate relays for opening and closing the garage door. In
 Composer Pro, you should configure the relay settings as follows:
 
 - Set to **2 Relays** (Open/Close) or **3 Relays** (Open/Close/Stop)
-  - The driver creates separate relays for opening and closing the garage door
   - The stop relay is only created when the device reports support for it. If
     you are not sure, look at the connections in Composer Pro to see if the
     "Stop" relay is available, and configure for 3 relays if it is.

--- a/drivers/esphome/www/documentation/index.md
+++ b/drivers/esphome/www/documentation/index.md
@@ -88,12 +88,13 @@ monitoring and control of ESPHome devices directly from your Control4 system.
 This driver will generically work with any ESPHome device, but we have tested
 extensively with the following devices:
 
-- [ratgdo](https://ratcloud.llc) -
-  [Garage Door Configuration Guide](#garage-door-configuration-guide)
+- [ratgdo](https://ratcloud.llc)
 - konnected Smart Garage Door Opener -
   [blaQ](https://konnected.io/products/smart-garage-door-opener-blaq-myq-alternative)
-  / [White](https://konnected.io/products/smart-garage-door-opener) -
-  [Garage Door Configuration Guide](#garage-door-configuration-guide)
+  / [White](https://konnected.io/products/smart-garage-door-opener)
+
+Both are relay-based garage door controllers - see the
+[Garage Door Configuration Guide](#garage-door-configuration-guide).
 
 If you try this driver on a product listed above, and it works, let us know!
 
@@ -646,10 +647,16 @@ bindings are created separately from the entity bindings above:
 
 # <span style="color:#17BCF2">Garage Door Configuration Guide</span>
 
-This guide provides instructions for configuring the ESPHome driver to work with
-ratgdo devices for garage door control via relays in Control4 Composer Pro.
-Other relay-based garage door controllers, such as konnected's Smart Garage Door
-Opener, should be configured similarly.
+This guide provides instructions for configuring the ESPHome driver for garage
+door control via relays in Control4 Composer Pro. It applies to any ESPHome
+device that exposes a cover entity, including ratgdo and konnected's Smart
+Garage Door Opener.
+
+The driver names the relay and contact bindings after the cover entity, so the
+labels shown in Composer Pro depend on the device. ratgdo names its cover
+"Door", giving "Open Door" and "Door Closed". konnected defaults to "Garage
+Door", giving "Open Garage Door" and "Garage Door Closed". Substitute your
+device's cover name throughout this guide.
 
 ## Add Relay Controller Driver
 
@@ -660,27 +667,25 @@ Pro.
 
 ## Relay Controller Properties
 
-The ratgdo device exposes a "Cover" entity in ESPHome, which maps to the relay
+The device exposes a "Cover" entity in ESPHome, which maps to the relay
 controller functionality in Control4.
 
 ### Number of Relays
 
-The ratgdo device uses a multi-relay configuration to control the garage door.
-In Composer Pro, you should configure the relay settings as follows:
+The driver creates separate relays for opening and closing the garage door. In
+Composer Pro, you should configure the relay settings as follows:
 
 - Set to **2 Relays** (Open/Close) or **3 Relays** (Open/Close/Stop)
-  - The ratgdo device uses separate commands for opening and closing the garage
-    door
-  - If your ratgdo firmware supports the "stop" command, configure for 3 relays
-    to enable the stop functionality. If you are not sure, you can look at the
-    ratgdo connections in Composer Pro to see if the "Stop Door" relay is
-    available.
+  - The driver creates separate relays for opening and closing the garage door
+  - The stop relay is only created when the device reports support for it. If
+    you are not sure, look at the connections in Composer Pro to see if the
+    "Stop" relay is available, and configure for 3 relays if it is.
 
 ### Relay Configuration
 
 - Set to **Pulse**
-  - ratgdo uses momentary pulses to trigger the garage door opener, similar to a
-    wall button press
+  - These devices use momentary pulses to trigger the garage door opener,
+    similar to a wall button press
 
 ### Pulse Time
 
@@ -711,14 +716,17 @@ Pro:
 
 ### Relays
 
-- **Open**: Connect to the ratgdo's "Open Door" relay
-- **Close**: Connect to the ratgdo's "Close Door" relay
-- **Stop**: Connect to the ratgdo's "Stop Door" relay, if available
+Where `{cover}` is the name of the device's cover entity ("Door" on ratgdo,
+"Garage Door" on konnected):
+
+- **Open**: Connect to the "Open {cover}" relay
+- **Close**: Connect to the "Close {cover}" relay
+- **Stop**: Connect to the "Stop {cover}" relay, if available
 
 ### Contact Sensors
 
-- **Closed Contact**: Connect to the ratgdo's "Door Closed" contact
-- **Opened Contact**: Connect to the ratgdo's "Door Open" contact
+- **Closed Contact**: Connect to the "{cover} Closed" contact
+- **Opened Contact**: Connect to the "{cover} Open" contact
 
 ### Example Connections
 
@@ -746,14 +754,16 @@ Using the "Still Open Time" property from the relay controller driver:
 
 ## Additional Entities
 
-Depending on your ratgdo device, firmware, and its capabilities, there may be
+Depending on your device, firmware, and its capabilities, there may be
 additional entities exposed by the ESPHome driver. These can come as additional
 connections or driver variables.
 
-Please refer to ratgdo's documentation for more information on specific
+Please refer to your device's documentation for more information on specific
 entities:
 
-https://ratgdo.github.io/esphome-ratgdo/webui_documentation.html
+- ratgdo: https://ratgdo.github.io/esphome-ratgdo/webui_documentation.html
+- konnected:
+  https://support.konnected.io/esphome-on-the-konnected-garage-door-opener
 
 # <span style="color:#17BCF2">Bluetooth Proxy Configuration Guide</span>
 

--- a/drivers/esphome_bluetooth_coordinator/www/documentation/index.md
+++ b/drivers/esphome_bluetooth_coordinator/www/documentation/index.md
@@ -121,8 +121,6 @@ with BLE devices.
 
 </div>
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">System Requirements</span>
 
 - Control4 OS 3.3+
@@ -258,8 +256,6 @@ If you want room-level presence tracking:
 1. In the **Select Presence Devices** dropdown, select devices to track
 1. Adjust presence settings as needed (see
    [Presence Settings](#presence-settings))
-
-<div style="page-break-after: always"></div>
 
 # <span style="color:#17BCF2">Driver Properties</span>
 
@@ -400,8 +396,6 @@ specific room.
 > regardless of strength. Individual proxies can override this value (see
 > ESPHome driver "Minimum Room RSSI Override" property).
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">Connections</span>
 
 ## Bluetooth Proxies (provider)
@@ -424,8 +418,6 @@ The coordinator dynamically creates CONTACT_SENSOR bindings for presence
 tracking integration. See [Contact Sensor Bindings](#contact-sensor-bindings)
 for details.
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">Driver Actions</span>
 
 ## Reset Driver
@@ -439,8 +431,6 @@ or are experiencing issues.
 **Parameters:**
 
 - **Are You Sure?** \[ **_No_** | Yes \] - Confirmation to reset the driver.
-
-<div style="page-break-after: always"></div>
 
 # <span style="color:#17BCF2">Presence Tracking</span>
 
@@ -574,8 +564,6 @@ address for devices, room ID for rooms) to avoid conflicts.
 ### Device Presence Bindings
 
 - **[Device] [MAC] Present** - CLOSED when device is home, OPENED when away
-
-<div style="page-break-after: always"></div>
 
 # <span style="color:#17BCF2">Best Practices</span>
 
@@ -711,8 +699,6 @@ Each proxy forwards BLE advertisements to the coordinator. In busy environments:
 **Mitigation:** The coordinator filters advertisements to only process devices
 you've explicitly selected. Unselected devices are ignored.
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">Troubleshooting</span>
 
 ## Presence Flapping Between Rooms
@@ -831,7 +817,5 @@ https://github.com/finitelabs/control4-esphome/issues/new
 <a href="https://www.buymeacoffee.com/derek.miller" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 
 <!-- #endif -->
-
-<div style="page-break-after: always"></div>
 
 <!-- #embed-changelog -->

--- a/drivers/esphome_bthome/www/documentation/index.md
+++ b/drivers/esphome_bthome/www/documentation/index.md
@@ -69,8 +69,6 @@ Control4.
 
 </div>
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">System Requirements</span>
 
 - Control4 OS 3.3+
@@ -110,8 +108,6 @@ Common BTHome devices include:
 | Xiaomi       | Sensors with BTHome firmware (custom flash required) |
 | b-parasite   | Open-source soil moisture sensor                     |
 | DIY          | ESP32-based sensors with BTHome firmware             |
-
-<div style="page-break-after: always"></div>
 
 # <span style="color:#17BCF2">Installer Setup</span>
 
@@ -350,8 +346,6 @@ Resets the driver state and clears cached sensor values.
 
 - **Are You Sure?** \[ **_No_** | Yes \] - Confirmation to reset the driver.
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">Programming</span>
 
 ## Events
@@ -546,8 +540,6 @@ will only appear after the device has broadcast data of the corresponding type.
 Binary sensor bindings (CONTACT_SENSOR) integrate with Control4's Contact Sensor
 proxy for programming and automation.
 
-<div style="page-break-after: always"></div>
-
 <!-- #ifdef DRIVERCENTRAL -->
 
 # <span style="color:#17BCF2">Developer Information</span>
@@ -588,7 +580,5 @@ https://github.com/finitelabs/control4-esphome/issues/new
 <a href="https://www.buymeacoffee.com/derek.miller" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 
 <!-- #endif -->
-
-<div style="page-break-after: always"></div>
 
 <!-- #embed-changelog -->

--- a/drivers/esphome_climate/www/documentation/index.md
+++ b/drivers/esphome_climate/www/documentation/index.md
@@ -61,8 +61,6 @@ thermostat proxy.
 
 </div>
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">System Requirements</span>
 
 - Control4 OS 3.3+
@@ -205,8 +203,6 @@ values.
 Outputs the climate device's current humidity reading to other Control4 drivers
 via a `HUMIDITY_VALUE` connection.
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">Remote Temperature Sensor</span>
 
 The remote temperature sensor feature allows a Control4 temperature sensor
@@ -282,8 +278,6 @@ Remote Temperature Sensor** in the thermostat UI (Navigator or the C4 app) to
 begin forwarding readings. Disabling the toggle calls the **Internal Temperature
 Service** (if configured) so the device reverts to its built-in sensor.
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">Water Heater Support</span>
 
 ESPHome water heater entities are supported as single-setpoint thermostat
@@ -300,8 +294,6 @@ the thermostat proxy accordingly:
 
 When switching the thermostat from Off to Heat, the driver restores the last
 selected water heater operating mode.
-
-<div style="page-break-after: always"></div>
 
 <!-- #ifdef DRIVERCENTRAL -->
 
@@ -343,7 +335,5 @@ https://github.com/finitelabs/control4-esphome/issues/new
 <a href="https://www.buymeacoffee.com/derek.miller" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 
 <!-- #endif -->
-
-<div style="page-break-after: always"></div>
 
 <!-- #embed-changelog -->

--- a/drivers/esphome_fan/www/documentation/index.md
+++ b/drivers/esphome_fan/www/documentation/index.md
@@ -57,8 +57,6 @@ allowing them to be controlled through the Control4 fan proxy with
 
 </div>
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">System Requirements</span>
 
 - Control4 OS 3.3+
@@ -105,8 +103,6 @@ fan's `speed_count` in its ESPHome configuration:
 The main ESPHome driver automatically creates a binding based on the fan's
 reported speed count and direction support, ensuring only the matching variant
 can be bound.
-
-<div style="page-break-after: always"></div>
 
 # <span style="color:#17BCF2">Installer Setup</span>
 
@@ -204,8 +200,6 @@ The driver provides button link connections for programming integration:
 
 <!-- #endif -->
 
-<div style="page-break-after: always"></div>
-
 <!-- #ifdef DRIVERCENTRAL -->
 
 # <span style="color:#17BCF2">Developer Information</span>
@@ -246,7 +240,5 @@ https://github.com/finitelabs/control4-esphome/issues/new
 <a href="https://www.buymeacoffee.com/derek.miller" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 
 <!-- #endif -->
-
-<div style="page-break-after: always"></div>
 
 <!-- #embed-changelog -->

--- a/drivers/esphome_govee/www/documentation/index.md
+++ b/drivers/esphome_govee/www/documentation/index.md
@@ -67,8 +67,6 @@ Control4.
 
 </div>
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">System Requirements</span>
 
 - Control4 OS 3.3+
@@ -124,8 +122,6 @@ Control4.
 | H5185 | 1      | Probe 1      | ✅           |
 | H5191 | 1      | Probe 1      | ✅           |
 | H5198 | 2      | Probe 1, 2   | ✅           |
-
-<div style="page-break-after: always"></div>
 
 # <span style="color:#17BCF2">Installer Setup</span>
 
@@ -287,8 +283,6 @@ Resets the driver state and clears cached sensor values.
 
 - **Are You Sure?** \[ **_No_** | Yes \] - Confirmation to reset the driver.
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">Programming</span>
 
 ## Events
@@ -389,8 +383,6 @@ received:
 These bindings can be connected to other Control4 devices that consume
 temperature or humidity values (e.g., climate displays, thermostats).
 
-<div style="page-break-after: always"></div>
-
 <!-- #ifdef DRIVERCENTRAL -->
 
 # <span style="color:#17BCF2">Developer Information</span>
@@ -431,7 +423,5 @@ https://github.com/finitelabs/control4-esphome/issues/new
 <a href="https://www.buymeacoffee.com/derek.miller" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 
 <!-- #endif -->
-
-<div style="page-break-after: always"></div>
 
 <!-- #embed-changelog -->

--- a/drivers/esphome_light/www/documentation/index.md
+++ b/drivers/esphome_light/www/documentation/index.md
@@ -55,8 +55,6 @@ entities, allowing them to be controlled through the Control4 light proxy.
 
 </div>
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">System Requirements</span>
 
 - Control4 OS 3.3+
@@ -100,8 +98,6 @@ color-temperature, and full-color lights are all supported.
 | [RGBWW](https://esphome.io/components/light/rgbww)                         | ✅        |
 
 </div>
-
-<div style="page-break-after: always"></div>
 
 # <span style="color:#17BCF2">Installer Setup</span>
 
@@ -171,8 +167,6 @@ The driver provides three button link connections for programming integration:
 | Toggle Button Link | Toggles the light when triggered   |
 | Off Button Link    | Turns the light off when triggered |
 
-<div style="page-break-after: always"></div>
-
 <!-- #ifdef DRIVERCENTRAL -->
 
 # <span style="color:#17BCF2">Developer Information</span>
@@ -213,7 +207,5 @@ https://github.com/finitelabs/control4-esphome/issues/new
 <a href="https://www.buymeacoffee.com/derek.miller" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 
 <!-- #endif -->
-
-<div style="page-break-after: always"></div>
 
 <!-- #embed-changelog -->

--- a/drivers/esphome_lock/www/documentation/index.md
+++ b/drivers/esphome_lock/www/documentation/index.md
@@ -55,8 +55,6 @@ allowing them to be controlled through the Control4 lock proxy.
 
 </div>
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">System Requirements</span>
 
 - Control4 OS 3.3+
@@ -70,8 +68,6 @@ allowing them to be controlled through the Control4 lock proxy.
 - Open Latch action and programming command for latch-style locks that support
   the open action
 - Real-time state synchronization with ESPHome device
-
-<div style="page-break-after: always"></div>
 
 # <span style="color:#17BCF2">Installer Setup</span>
 
@@ -151,8 +147,6 @@ configured **Lock Code** when one is set. Logs a warning and does nothing if the
 connected lock does not support open, or if the lock entity has not been
 discovered yet.
 
-<div style="page-break-after: always"></div>
-
 <!-- #ifdef DRIVERCENTRAL -->
 
 # <span style="color:#17BCF2">Developer Information</span>
@@ -193,7 +187,5 @@ https://github.com/finitelabs/control4-esphome/issues/new
 <a href="https://www.buymeacoffee.com/derek.miller" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 
 <!-- #endif -->
-
-<div style="page-break-after: always"></div>
 
 <!-- #embed-changelog -->

--- a/drivers/esphome_switchbot/www/documentation/index.md
+++ b/drivers/esphome_switchbot/www/documentation/index.md
@@ -78,8 +78,6 @@ Sensors, Contact Sensors, and Water Leak Detectors.
 
 </div>
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">System Requirements</span>
 
 - Control4 OS 3.3+
@@ -119,8 +117,6 @@ Sensors, Contact Sensors, and Water Leak Detectors.
 | Contact Sensor       | Passive | CONTACT_SENSOR + BUTTON_LINK + Events | No         |
 | Water Leak Detector  | Passive | CONTACT_SENSOR + Events               | No         |
 | Remote               | Passive | (advertisement parsing only)          | No         |
-
-<div style="page-break-after: always"></div>
 
 # <span style="color:#17BCF2">Installer Setup</span>
 
@@ -321,8 +317,6 @@ Resets the driver state to defaults.
 
 - **Are You Sure?** \[ **_No_** | Yes \] - Confirmation to reset the driver.
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">Device Types</span>
 
 ## Bot
@@ -436,8 +430,6 @@ Water leak detection sensor with tamper detection.
 - Low Battery - Battery is low
 - Battery OK - Battery restored to normal
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">Programming</span>
 
 ## Events
@@ -519,8 +511,6 @@ The driver dynamically creates bindings based on the detected device type:
 | TEMPERATURE_VALUE | Meters                          | Temperature in Celsius   |
 | HUMIDITY_VALUE    | Meters                          | Humidity percentage      |
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">Troubleshooting</span>
 
 ## Device Not Responding
@@ -559,8 +549,6 @@ If the driver detects the wrong device type:
 1. Use "Reset Driver" action to clear state
 1. Unbind and rebind the device connection
 1. Ensure you're binding to the correct device
-
-<div style="page-break-after: always"></div>
 
 <!-- #ifdef DRIVERCENTRAL -->
 
@@ -602,7 +590,5 @@ https://github.com/finitelabs/control4-esphome/issues/new
 <a href="https://www.buymeacoffee.com/derek.miller" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 
 <!-- #endif -->
-
-<div style="page-break-after: always"></div>
 
 <!-- #embed-changelog -->

--- a/drivers/esphome_yale/www/documentation/index.md
+++ b/drivers/esphome_yale/www/documentation/index.md
@@ -76,8 +76,6 @@ is only used during initial setup to retrieve the offline key.
 
 </div>
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">System Requirements</span>
 
 - Control4 OS 3.3+
@@ -122,8 +120,6 @@ Bluetooth.
 > **Note:** Other Yale/August locks using the same BLE protocol may also work.
 > Yale Conexis (L1/L2) and Yale Smart Cabinet Lock have limited protocol support
 > (lock/unlock only, no status updates).
-
-<div style="page-break-after: always"></div>
 
 # <span style="color:#17BCF2">How It Works</span>
 
@@ -176,8 +172,6 @@ After a lock or unlock command, the driver re-queries lock status to confirm the
 operation succeeded. If the lock reports a jam, the status is updated to `fault`
 on the Control4 lock proxy.
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">Installer Setup</span>
 
 <!-- #ifdef DRIVERCENTRAL -->
@@ -225,8 +219,6 @@ advertisement.
 > **Note:** If the Yale cloud API reports that the key is "provisioned but not
 > yet loaded," you need to operate the lock once from the Yale app to load the
 > key onto the lock hardware, then retry key fetching.
-
-<div style="page-break-after: always"></div>
 
 ## Driver Properties
 
@@ -466,8 +458,6 @@ expose open/closed state to Control4 programming, room occupancy, and
 notifications. The binding is not created on locks that do not report a
 DoorSense configuration.
 
-<div style="page-break-after: always"></div>
-
 # <span style="color:#17BCF2">Troubleshooting</span>
 
 **"Error: Offline key required"** The offline key has not been configured. Use
@@ -504,8 +494,6 @@ Yale Access app first.
 **Key stops working after using the Yale app** The Yale/August cloud may rotate
 the offline key when the lock is operated from a mobile device. If this happens,
 re-run the **Verify and Fetch Keys** action to retrieve the updated key.
-
-<div style="page-break-after: always"></div>
 
 <!-- #ifdef DRIVERCENTRAL -->
 
@@ -547,7 +535,5 @@ https://github.com/finitelabs/control4-esphome/issues/new
 <a href="https://www.buymeacoffee.com/derek.miller" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 
 <!-- #endif -->
-
-<div style="page-break-after: always"></div>
 
 <!-- #embed-changelog -->


### PR DESCRIPTION
## Summary
- **DRV-69**: DriverCentral's published listing includes konnected's Smart Garage Door Opener (blaQ and White) under Verified Devices, but the entry was missing from the repo's source docs. Adds it with links to both variants.
- Generalizes the ratgdo-specific configuration guide to a **Garage Door Configuration Guide**, noting it is written for ratgdo but that other relay-based controllers should be configured similarly. Both verified devices now link to it.
- Drops the 57 hand-placed `page-break-after` divs across all 10 driver doc sources. The template moved to automatic pagination in v0.9.11, so the manual breaks no longer match how the PDFs are rendered.

Closes DRV-69

## Test plan
- [x] `make build` runs clean; all 20 PDFs render
- [x] `README.md` regenerates from source with no page-break divs remaining
- [x] No `page-break` occurrences left in any tracked Markdown