### PR TITLE
DRV-66: Skip clearing BLE device-selection property before it's registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 - Removed
 -->
 
+## Unreleased
+
+### Fixed
+
+- Fixed Bluetooth proxy instances bound to a coordinator logging a spurious
+  "Property 'Select Bluetooth Devices' not registered" warning once at every
+  driver startup
+
 ## v20260802 - 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -904,6 +904,14 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 - Removed
 -->
 
+## Unreleased
+
+### Fixed
+
+- Fixed Bluetooth proxy instances bound to a coordinator logging a spurious
+  "Property 'Select Bluetooth Devices' not registered" warning once at every
+  driver startup
+
 ## v20260802 - 2026-08-02
 
 ### Added

--- a/src/esphome/ble/scanner_properties.lua
+++ b/src/esphome/ble/scanner_properties.lua
@@ -110,6 +110,13 @@ function BLEScannerProperties:setLimit(propertyName, limit)
   end
 end
 
+--- Check whether a property has been registered.
+--- @param propertyName string The property name
+--- @return boolean
+function BLEScannerProperties:isRegistered(propertyName)
+  return self._properties[propertyName] ~= nil
+end
+
 --- Get the current limit for a property.
 --- @param propertyName string The property name
 --- @return number|nil limit The current limit (nil = unlimited)

--- a/src/esphome/capabilities/bluetooth_proxy.lua
+++ b/src/esphome/capabilities/bluetooth_proxy.lua
@@ -1324,8 +1324,10 @@ function BluetoothProxyCapability:onCoordinatorBindingChanged(bIsBound)
       self:removeDevice(mac)
     end
 
-    -- Clear persisted device selection
-    bleScannerProperties:clearSelection(self.PROPERTY_NAME)
+    -- Clear persisted device selection, if the property has been registered (DRV-66)
+    if bleScannerProperties:isRegistered(self.PROPERTY_NAME) then
+      bleScannerProperties:clearSelection(self.PROPERTY_NAME)
+    end
 
     -- Start forwarding all advertisements to coordinator
     self:_startCoordinatorForwarding()

--- a/src/esphome/capabilities/bluetooth_proxy.lua
+++ b/src/esphome/capabilities/bluetooth_proxy.lua
@@ -1324,7 +1324,8 @@ function BluetoothProxyCapability:onCoordinatorBindingChanged(bIsBound)
       self:removeDevice(mac)
     end
 
-    -- A bound coordinator can replay before discovered() has registered the property
+    -- discovered() creates the coordinator binding before registering the property,
+    -- so an already-bound coordinator fires this synchronously from there
     if bleScannerProperties:isRegistered(self.PROPERTY_NAME) then
       bleScannerProperties:clearSelection(self.PROPERTY_NAME)
     end

--- a/src/esphome/capabilities/bluetooth_proxy.lua
+++ b/src/esphome/capabilities/bluetooth_proxy.lua
@@ -1324,7 +1324,7 @@ function BluetoothProxyCapability:onCoordinatorBindingChanged(bIsBound)
       self:removeDevice(mac)
     end
 
-    -- Clear persisted device selection, if the property has been registered (DRV-66)
+    -- A bound coordinator can replay before discovered() has registered the property
     if bleScannerProperties:isRegistered(self.PROPERTY_NAME) then
       bleScannerProperties:clearSelection(self.PROPERTY_NAME)
     end


### PR DESCRIPTION
## Summary
- Bluetooth-proxy-capable ESPHome instances logged a WARN once every startup: `Property 'Select Bluetooth Devices' not registered`.
- Cause: the coordinator binding replay at startup can clear the persisted device selection before `discovered()` has registered the property (registration only happens after the device connects). No functional effect, just log noise.
- Added `BLEScannerProperties:isRegistered()` and guarded the clear so it's skipped when the property isn't registered yet.

Closes DRV-66

## Test plan
- [x] `make build-nodocs` runs clean
- [x] Traced that skipping the clear has no functional effect: `setDevices` already no-ops whenever the coordinator is connected