### PR TITLE
DRV-66: Back the BLE device selection property from driver init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 - Removed
 -->
 
+## Unreleased
+
+### Fixed
+
+- Fixed Bluetooth proxies logging a spurious "Property 'Select Bluetooth
+  Devices' not registered" warning at every driver startup
+- Fixed the Bluetooth device selection being permanently erased when a proxy was
+  bound to a Bluetooth Coordinator; it is now kept and restored if the proxy is
+  later unbound
+- Fixed Bluetooth proxies in Coordinator Mode reporting their connection slots
+  as "(Oversubscribed)"
+
 ## v20260802 - 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -906,6 +906,18 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 - Removed
 -->
 
+## Unreleased
+
+### Fixed
+
+- Fixed Bluetooth proxies logging a spurious "Property 'Select Bluetooth
+  Devices' not registered" warning at every driver startup
+- Fixed the Bluetooth device selection being permanently erased when a proxy was
+  bound to a Bluetooth Coordinator; it is now kept and restored if the proxy is
+  later unbound
+- Fixed Bluetooth proxies in Coordinator Mode reporting their connection slots
+  as "(Oversubscribed)"
+
 ## v20260802 - 2026-08-02
 
 ### Added

--- a/drivers/esphome/driver.lua
+++ b/drivers/esphome/driver.lua
@@ -147,6 +147,11 @@ function OnDriverLateInit()
   -- Hide Bluetooth Proxy properties until we detect support
   bluetoothProxyCapability:setPropertiesAttribs(constants.HIDE_PROPERTY)
 
+  -- Back the device selection property before anything can reach it. The
+  -- selection is persisted configuration, so it must not wait on the connect
+  -- that detects proxy support.
+  bluetoothProxyCapability:registerDeviceSelectionProperty()
+
   C4:FileSetDir("c29tZXNwZWNpYWxrZXk=++11")
 
   -- Fire OnPropertyChanged to set the initial Headers and other Property

--- a/src/esphome/ble/scanner_properties.lua
+++ b/src/esphome/ble/scanner_properties.lua
@@ -11,6 +11,9 @@ local bleScanner = require("esphome.ble.scanner")
 --- @field onChanged? fun(selectedDevices: table<string, BLEDiscoveredDevice?>) Called on initial load and when selection changes
 --- @field limit? number Maximum devices that can be selected (nil = unlimited)
 --- @field filter? fun(device: BLEDiscoveredDevice): boolean Filter function; return true to include device
+--- @field deferInitialCallback? boolean Skip the initial onChanged fire so the property can be
+---   registered before the driver is ready to act on the selection. The caller is then
+---   responsible for calling applySelection() once it is.
 
 --- @class PropertyRegistration : PropertyRegistrationOptions
 --- @field selectedDevices table<string, BLEDiscoveredDevice?> Currently selected devices keyed by MAC
@@ -60,15 +63,36 @@ function BLEScannerProperties:registerProperty(propertyName, options)
   )
 
   -- Fire initial callback with current selection
-  if options.onChanged and TableLength(selectedDevices) > 0 then
-    local success, err = pcall(options.onChanged, selectedDevices)
-    if not success then
-      log:error("Property '%s' onChanged callback failed: %s", propertyName, err or "unknown error")
-    end
+  if not options.deferInitialCallback then
+    self:applySelection(propertyName)
   end
 
   -- Initialize the property list with default options
   self:updateProperty(propertyName, false)
+end
+
+--- Fire a property's onChanged callback with its current selection.
+--- Only needed after a registration that deferred the initial callback, to apply
+--- the stored selection once the driver is ready to act on it.
+--- @param propertyName string The property name
+function BLEScannerProperties:applySelection(propertyName)
+  log:trace("BLEScannerProperties:applySelection(%s)", propertyName)
+
+  local registration = self._properties[propertyName]
+  if not registration then
+    log:warn("Property '%s' not registered", propertyName)
+    return
+  end
+
+  local selectedDevices = registration.selectedDevices or {}
+  if not registration.onChanged or TableLength(selectedDevices) == 0 then
+    return
+  end
+
+  local success, err = pcall(registration.onChanged, selectedDevices)
+  if not success then
+    log:error("Property '%s' onChanged callback failed: %s", propertyName, err or "unknown error")
+  end
 end
 
 --- Update the limit for a property.

--- a/src/esphome/ble/scanner_properties.lua
+++ b/src/esphome/ble/scanner_properties.lua
@@ -134,48 +134,6 @@ function BLEScannerProperties:setLimit(propertyName, limit)
   end
 end
 
---- Get the current limit for a property.
---- @param propertyName string The property name
---- @return number|nil limit The current limit (nil = unlimited)
-function BLEScannerProperties:getLimit(propertyName)
-  log:trace("BLEScannerProperties:getLimit(%s)", propertyName)
-
-  local registration = self._properties[propertyName]
-  if not registration then
-    log:warn("Property '%s' not registered", propertyName)
-    return nil
-  end
-  return registration.limit
-end
-
---- Get selected devices for a property.
---- @param propertyName string The property name
---- @return table<string, BLEDiscoveredDevice?> selectedDevices Map of MAC to device info
-function BLEScannerProperties:getSelectedDevices(propertyName)
-  log:trace("BLEScannerProperties:getSelectedDevices(%s)", propertyName)
-
-  local registration = self._properties[propertyName]
-  if not registration then
-    log:warn("Property '%s' not registered", propertyName)
-    return {}
-  end
-  return registration.selectedDevices or {}
-end
-
---- Get all selected MACs across all properties (for cache management).
---- @return table<string, boolean?> allSelectedMacs Map of MAC to true
-function BLEScannerProperties:getAllSelectedMacs()
-  log:trace("BLEScannerProperties:getAllSelectedMacs()")
-
-  local allMacs = {}
-  for _, registration in pairs(self._properties) do
-    for mac, _ in pairs(registration.selectedDevices or {}) do
-      allMacs[mac] = true
-    end
-  end
-  return allMacs
-end
-
 --- Count selected devices that require active connections (non-passive).
 --- @param propertyName string The property name
 --- @return number count Number of selected devices requiring active connections
@@ -371,36 +329,6 @@ function BLEScannerProperties:handleSelection(propertyName, propertyValue)
   end
 
   return true
-end
-
---- Clear the selection for a specific property.
---- @param propertyName string The property name
-function BLEScannerProperties:clearSelection(propertyName)
-  log:trace("BLEScannerProperties:clearSelection(%s)", propertyName)
-  local registration = self._properties[propertyName]
-  if not registration then
-    log:warn("Property '%s' not registered", propertyName)
-    return
-  end
-
-  -- Clear the persisted selection
-  persist:delete(registration.persistKey)
-
-  -- Clear the in-memory selection
-  registration.selectedDevices = {}
-
-  -- Update the property UI
-  self:updateProperty(propertyName, false)
-
-  -- Fire onChanged callback with empty selection
-  if registration.onChanged then
-    local success, err = pcall(registration.onChanged, {})
-    if not success then
-      log:error("Property '%s' onChanged callback failed: %s", propertyName, err or "unknown error")
-    end
-  end
-
-  log:info("Cleared selection for property '%s'", propertyName)
 end
 
 --- Resets all registered properties, clearing selections and persisted data.

--- a/src/esphome/capabilities/bluetooth_proxy.lua
+++ b/src/esphome/capabilities/bluetooth_proxy.lua
@@ -302,9 +302,13 @@ function BluetoothProxyCapability:_updateStatusProperty()
 
   -- Build connection slots text with optional oversubscription warning
   local slotsText = string.format("%d/%d Active", connState.limit - connState.free, connState.limit)
-  local selectedActiveCount = bleScannerProperties:getSelectedActiveCount(self.PROPERTY_NAME)
-  if selectedActiveCount > connState.limit then
-    slotsText = slotsText .. " (Oversubscribed)"
+  -- The selection only drives local connections in standalone mode; under a
+  -- coordinator it is retained but dormant, so it cannot oversubscribe anything.
+  if not self._coordinatorConnected then
+    local selectedActiveCount = bleScannerProperties:getSelectedActiveCount(self.PROPERTY_NAME)
+    if selectedActiveCount > connState.limit then
+      slotsText = slotsText .. " (Oversubscribed)"
+    end
   end
   table.insert(parts, slotsText)
 
@@ -1034,8 +1038,34 @@ function BluetoothProxyCapability:isConnected(mac)
   return self._client:isBluetoothDeviceAllocated(mac)
 end
 
+--- Register the device selection property with BLEScannerProperties.
+--- Call this from driver init, before connecting.
+---
+--- The registration itself is pure driver configuration: the selection and the
+--- device list both come from persistent storage, so nothing here needs the
+--- ESPHome device. Registering at init keeps the property's backing state
+--- available for the whole life of the driver instead of only after the first
+--- successful connect, which is what left startup callers warning about an
+--- unregistered property.
+---
+--- Acting on the selection is deferred to discovered(), because whether the
+--- devices should be managed locally depends on the coordinator binding.
+function BluetoothProxyCapability:registerDeviceSelectionProperty()
+  log:trace("BluetoothProxyCapability:registerDeviceSelectionProperty()")
+
+  bleScannerProperties:registerProperty(self.PROPERTY_NAME, {
+    persistKey = SELECTED_BLUETOOTH_DEVICES_PERSIST_KEY,
+    deferInitialCallback = true,
+    filter = function(device)
+      return device.bindingClass ~= nil
+    end,
+    onChanged = function(selectedDevices)
+      self:setDevices(selectedDevices)
+    end,
+  })
+end
+
 --- Handle the discovery of bluetooth proxy capability.
---- Registers the device selection property with BLEScannerProperties.
 --- @param deviceInfo ProtoDeviceInfoResponse|nil Device info containing feature flags
 function BluetoothProxyCapability:discovered(deviceInfo)
   log:trace("BluetoothProxyCapability:discovered(%s)", deviceInfo)
@@ -1055,19 +1085,12 @@ function BluetoothProxyCapability:discovered(deviceInfo)
   -- Show Bluetooth Proxy properties
   self:setPropertiesAttribs(constants.SHOW_PROPERTY)
 
-  -- Create dynamic binding for coordinator communication
+  -- Create dynamic binding for coordinator communication. This settles whether a
+  -- coordinator owns device management before the selection below is applied.
   self:_createCoordinatorBinding()
 
-  -- Register property with BLEScannerProperties
-  bleScannerProperties:registerProperty(self.PROPERTY_NAME, {
-    persistKey = SELECTED_BLUETOOTH_DEVICES_PERSIST_KEY,
-    filter = function(device)
-      return device.bindingClass ~= nil
-    end,
-    onChanged = function(selectedDevices)
-      self:setDevices(selectedDevices)
-    end,
-  })
+  -- Apply the stored device selection (a no-op while a coordinator is bound)
+  bleScannerProperties:applySelection(self.PROPERTY_NAME)
 
   -- Register callback for ongoing connection slot updates
   self._client:addBluetoothConnectionsCallback("bluetooth_proxy_entity", function(state)
@@ -1294,6 +1317,52 @@ function BluetoothProxyCapability:onRoomChanged()
   }, "NOTIFY")
 end
 
+--- Enter coordinator mode and announce this proxy to the coordinator.
+--- The coordinator owns device management from here, so the locally added devices
+--- and their bindings are dropped. The selection that produced them is kept: it is
+--- inert while a coordinator is bound (setDevices and addDevice both no-op, and the
+--- property is hidden), and applySelection() restores the devices from it if the
+--- coordinator is later unbound.
+--- @private
+function BluetoothProxyCapability:_enterCoordinatorMode()
+  self._coordinatorConnected = true
+
+  -- Switch to coordinator mode properties: show room, hide device selection
+  self:setPropertiesAttribs(constants.SHOW_PROPERTY)
+
+  -- Hand device management over to the coordinator
+  -- Collect MACs first to avoid modifying table while iterating
+  local macsToRemove = {}
+  for mac in pairs(self._addedDevices) do
+    table.insert(macsToRemove, mac)
+  end
+
+  -- Remove all devices (stops monitoring, disconnects GATT, removes bindings)
+  for _, mac in ipairs(macsToRemove) do
+    self:removeDevice(mac)
+  end
+
+  -- Start forwarding all advertisements to coordinator
+  self:_startCoordinatorForwarding()
+
+  -- Send initial connection info to coordinator
+  local roomInfo = self:getRoomInfo()
+  local connState = self._client:getBluetoothConnectionState()
+
+  SendToProxy(self._coordinatorBindingId, "PROXY_CONNECTED", {
+    proxyId = tostring(C4:GetDeviceID()),
+    roomId = roomInfo and tostring(roomInfo.roomId) or "",
+    roomName = roomInfo and roomInfo.roomName or "",
+    connectionSlots = connState.initialized and tostring(connState.limit) or "0",
+    freeSlots = connState.initialized and tostring(connState.free) or "0",
+    featureFlags = tostring(self._featureFlags),
+    minRssiOverride = roomInfo and tostring(roomInfo.minRssiOverride) or "-100",
+  }, "NOTIFY")
+
+  -- Update status to indicate coordinator mode
+  self:_updateStatusProperty()
+end
+
 --- Handle coordinator binding state change.
 --- When coordinator connects, start forwarding all advertisements to it and disable local device management.
 --- When coordinator disconnects, stop forwarding and re-enable local device management.
@@ -1307,51 +1376,17 @@ function BluetoothProxyCapability:onCoordinatorBindingChanged(bIsBound)
   end
 
   if bIsBound then
-    self._coordinatorConnected = true
-
-    -- Switch to coordinator mode properties: show room, hide device selection
-    self:setPropertiesAttribs(constants.SHOW_PROPERTY)
-
-    -- Clean up all existing standalone mode state
-    -- Collect MACs first to avoid modifying table while iterating
-    local macsToRemove = {}
-    for mac in pairs(self._addedDevices) do
-      table.insert(macsToRemove, mac)
-    end
-
-    -- Remove all devices (stops monitoring, disconnects GATT, removes bindings)
-    for _, mac in ipairs(macsToRemove) do
-      self:removeDevice(mac)
-    end
-
-    -- Clear persisted device selection
-    bleScannerProperties:clearSelection(self.PROPERTY_NAME)
-
-    -- Start forwarding all advertisements to coordinator
-    self:_startCoordinatorForwarding()
-
-    -- Send initial connection info to coordinator
-    local roomInfo = self:getRoomInfo()
-    local connState = self._client:getBluetoothConnectionState()
-
-    SendToProxy(self._coordinatorBindingId, "PROXY_CONNECTED", {
-      proxyId = tostring(C4:GetDeviceID()),
-      roomId = roomInfo and tostring(roomInfo.roomId) or "",
-      roomName = roomInfo and roomInfo.roomName or "",
-      connectionSlots = connState.initialized and tostring(connState.limit) or "0",
-      freeSlots = connState.initialized and tostring(connState.free) or "0",
-      featureFlags = tostring(self._featureFlags),
-      minRssiOverride = roomInfo and tostring(roomInfo.minRssiOverride) or "-100",
-    }, "NOTIFY")
-
-    -- Update status to indicate coordinator mode
-    self:_updateStatusProperty()
+    self:_enterCoordinatorMode()
   else
     self._coordinatorConnected = false
     self:_stopCoordinatorForwarding()
 
     -- Switch back to standalone mode properties: hide room, show device selection
     self:setPropertiesAttribs(constants.SHOW_PROPERTY)
+
+    -- Take device management back by re-adding the devices that entering
+    -- coordinator mode dropped, from the selection it left intact.
+    bleScannerProperties:applySelection(self.PROPERTY_NAME)
 
     -- Re-enable local advertisement monitoring for bound devices
     for mac, device in pairs(self._addedDevices) do
@@ -1649,7 +1684,7 @@ function BluetoothProxyCapability:_createCoordinatorBinding()
   local boundProvider = C4:GetBoundProviderDevice(deviceId, binding.bindingId)
   if boundProvider and boundProvider > 0 then
     log:info("Coordinator already bound on startup (provider device %d), enabling forwarding", boundProvider)
-    self:onCoordinatorBindingChanged(true)
+    self:_enterCoordinatorMode()
   end
 end
 


### PR DESCRIPTION
Supersedes #90, which guarded the one call site that warned. This fixes why it warned.

## Root cause

`Select Bluetooth Devices` is a static `DYNAMIC_LIST` property in `driver.xml`, so it exists from driver load. The `BLEScannerProperties` registration behind it was created in `BluetoothProxyCapability:discovered()`, which only runs after the ESPHome device connects and reports `bluetooth_proxy_feature_flags`. Registration was tied to the **device-connection lifecycle** while every consumer of it is tied to the **driver lifecycle**.

Nothing in the registration needs the connection — the selection and the discovered device list both come from `persist`, the filter is pure, and the slot limit already arrives separately via `setLimit()`. So the coordinator binding replay in `_createCoordinatorBinding()` reached `clearSelection` three lines before the registration that would have made it valid. Deterministic, not a race.

The coordinator driver already registers its properties this way, unconditionally from `OnDriverLateInit` (`esphome_bluetooth_coordinator/driver.lua:667`). The proxy was the outlier.

## Changes

- `scanner_properties.lua` — `registerProperty()` gains `deferInitialCallback`; the initial `onChanged` fire moves to a new `applySelection()`. This splits *the property has backing state* (must be early) from *act on the selection* (must stay ordered after coordinator state is known). Reordering the two calls instead would add every standalone device at startup and immediately remove it.
- `esphome/driver.lua` — `registerDeviceSelectionProperty()` in `OnDriverLateInit`, before `Connect()`.
- `bluetooth_proxy.lua` — `discovered()` calls `applySelection()` where the registration used to sit. `_enterCoordinatorMode()` no longer clears the selection: it is inert under a coordinator (`setDevices` and `addDevice` both no-op, the property is hidden), so wiping it only destroyed installer configuration. Local device bindings are still dropped, since the coordinator owns device management, and unbinding calls `applySelection()` to rebuild them. Startup and runtime bind paths are now identical.
- Oversubscription is no longer reported in coordinator mode, where the selection drives no local connections.
- Second commit removes four `BLEScannerProperties` accessors with no callers.

Every accessor path now runs after registration, so that `log:warn` goes back to signalling a real programming error rather than a routine boot condition.

## Test plan

- [x] `make build` green; 21 `.c4z` artifacts; `README.md` regenerated from `CHANGELOG.md`
- [x] `gen-squishy` loads each `driver.lua` under `test/c4_shim.lua` and runs through `OnDriverLateInit` → `Connect()`, so the new init-time registration path executes during the build rather than only compiling
- [ ] Reload a coordinator-bound proxy (2715/2717/2777) with Log Level 5 and confirm no `Property 'Select Bluetooth Devices' not registered`

Closes DRV-66