### PR TITLE
Ignore coordinator binding events that do not change state

### DIFF
--- a/src/esphome/capabilities/bluetooth_proxy.lua
+++ b/src/esphome/capabilities/bluetooth_proxy.lua
@@ -1375,9 +1375,20 @@ function BluetoothProxyCapability:onCoordinatorBindingChanged(bIsBound)
     return
   end
 
+  -- Startup enters coordinator mode before OBC fires for the same binding
   if bIsBound then
+    if self._coordinatorConnected then
+      log:debug("Coordinator already bound, skipping transition")
+      return
+    end
+
     self:_enterCoordinatorMode()
   else
+    if not self._coordinatorConnected then
+      log:debug("Coordinator already unbound, skipping transition")
+      return
+    end
+
     self._coordinatorConnected = false
     self:_stopCoordinatorForwarding()
 


### PR DESCRIPTION
Follow-up to #91. This is the one idea from the abandoned `agent/fix-coordinator-binding-flap` branch (`a91ffc7`, April) that was worth keeping — the rest of that branch is superseded, since #91 removed the destructive selection clear it was reacting to. The branch has since been deleted; this is the salvage.

## Problem

`onCoordinatorBindingChanged` ran the full mode transition on every OBC event, including ones that repeated the state it was already in.

The startup path makes that reachable rather than hypothetical. `_createCoordinatorBinding` checks `C4:GetBoundProviderDevice` and calls `_enterCoordinatorMode()` directly (`bluetooth_proxy.lua:1698`), so a proxy with a bound coordinator is already in coordinator mode by the time Director fires OBC for that same binding. The second pass re-sends `PROXY_CONNECTED`.

On the coordinator that means a fresh `Proxy N connected` at INFO, a `_fireProxyChange("connected", ...)` callback, a status-property refresh and an advertisement-filter rebroadcast — per redundant event.

## Scope

`ProxyRegistry:onProxyConnected` (`proxy_registry.lua:101`) is an upsert keyed by device id, so no state is corrupted and nothing is duplicated. This is redundant work and a misleading log line, not damage. **No CHANGELOG entry** for that reason — the only observable is a DEBUG line.

## Why the guard is per-branch

The guard sits inside each branch rather than comparing `bIsBound` to `_coordinatorConnected` up front.

`bIsBound` arrives from Director via `vendor/drivers-common-public/global/handlers.lua:326`, which passes it through untouched, and every consumer in this repo tests it by truthiness alone (`sensor.lua:147`, `cover.lua:33`, `bthome/driver.lua:506`, `switchbot/driver.lua:742`, `onBindingChanged:873`). A single `==` comparison would therefore fail for a truthy non-boolean — `1 == true` is false, so the guard would not suppress, while `if bIsBound then` below would still take the bind branch. The guard would silently stop working in exactly the case it exists for.

Branching on truthiness reuses the existing test verbatim, so there is no conversion of the argument and nothing extra to reason about. `_coordinatorConnected` initializes to `false` (`:137`), so the guard is correct from the first event in both directions.

## Deliberately not guarded: reconnects

`discovered()` re-enters coordinator mode via `_createCoordinatorBinding`, not through this handler, so a reconnecting proxy still re-announces itself with fresh `connectionSlots` and `featureFlags`. That re-announce is wanted, which is why the guard is here rather than in `_enterCoordinatorMode`.

## Note on ordering

`_enterCoordinatorMode` sets `_coordinatorConnected = true` (`:1328`) before the rest of its work. If a future change adds a call there that can raise, the flag would be left set with `PROXY_CONNECTED` never sent, and this guard would suppress the OBC retry that currently papers over it.

Nothing on the path today can raise: `setPropertiesAttribs` and `_updateStatusProperty` bottom out in C4 property calls that print rather than throw, `deleteBinding` and `_startCoordinatorForwarding` early-return, `isBluetoothDeviceAllocated` scans a cached table, `bluetoothDeviceDisconnect` returns a Deferred, `getRoomInfo` returns `nil` on bad input, and `getBluetoothConnectionState` returns a cached table. Recorded because the ordering is load-bearing if that changes, not because it is reachable now.

Tightening it is not as simple as moving the assignment to the end: `setPropertiesAttribs` reads the flag (`:154`) to pick which properties to show and is called at `:1331`, so it would need a separate "announced" flag.

## Test plan

- [x] `make build` green, 21 OSS artifacts, `git status --porcelain` clean
- [ ] Bind and unbind a coordinator at runtime, confirm the transition still runs exactly once in each direction
- [ ] Reload a coordinator-bound proxy and confirm `PROXY_CONNECTED` is sent once, with the skip visible at DEBUG as `Coordinator already bound, skipping transition`