### PR TITLE
chore: copier update to template v0.9.15

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,13 +1,11 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.9.14
+_commit: v0.9.15
 _src_path: git@github.com:finitelabs/control4-driver-template.git
 distributions: drivercentral oss
 github_org: finitelabs
-lib_modules: bindings conditionals events http lru persist values
 primary_color: '#17BCF2'
 project_description: Integrate ESPHome-based devices into Control4
 project_name: control4-esphome
 readme_build: oss
 readme_driver_slug: esphome
-vendor_modules: json deferred drivers-common-public xml bitn crypto bthome noiseprotocol
-    protobuf protobuf
+vendor_modules: bitn crypto bthome noiseprotocol protobuf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Initialize project
         run: make init
 
+      - name: Check formatting
+        run: make check
+
       - name: Test
         run: make test
 
@@ -62,13 +65,13 @@ jobs:
       - name: Verify PDFs were generated
         run: |
           for build in drivercentral oss; do
-            pdf_count=$(find "dist/$build" -name '*.pdf' 2>/dev/null | wc -l)
+            pdf_count=$(find "dist/$build/docs" -name '*.pdf' 2>/dev/null | wc -l)
             if [ "$pdf_count" -eq 0 ]; then
-              echo "::error::No PDF files found in dist/$build"
-              ls -la "dist/$build/" || true
+              echo "::error::No PDF files found in dist/$build/docs"
+              ls -la "dist/$build/docs/" || true
               exit 1
             fi
-            echo "Found $pdf_count PDF(s) in dist/$build"
+            echo "Found $pdf_count PDF(s) in dist/$build/docs"
           done
 
       - name: Check for dirty tree

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,6 @@ jobs:
         with:
           generate_release_notes: true
           files: |
-            dist/oss/*.c4z
-            dist/oss/*.pdf
+            dist/oss/c4z/*.c4z
+            dist/oss/docs/*.pdf
             dist/oss/*.zip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,10 +38,10 @@ then pull the change in with `copier update`.
 
 - `JSON.lua`: JSON encoder/decoder
 - `deferred.lua`: promises/deferred implementation
-- `cloud-client-byte.lua`: DriverCentral cloud licensing
-- `version.lua`: semver comparison (used by github-updater)
 - `drivers-common-public/`: Control4's official shared libraries
 - `xml/`: XML parser (xml2lua)
+- `cloud-client-byte.lua`: DriverCentral cloud licensing
+- `version.lua`: semver comparison (used by github-updater)
 - `bitn.lua`: bit manipulation library
 - `crypto.lua`: cryptographic primitives (core build; requires `bitn`)
 - `bthome.lua`: BTHome protocol support
@@ -157,7 +157,11 @@ on a clean tree until something has populated `build/`.
 1. **Update driver.xml**: stamp version date and modified timestamp
 1. **Generate docs**: Markdown -> HTML -> PDF, plus README
 1. **Package**: run driverpackager to create .c4z files
-1. **Zip**: bundle .c4z and .pdf files per distribution
+1. **Zip**: bundle the c4z, docs and source folders per distribution
+
+Each distribution's outputs are grouped by type under `dist/<distribution>/`:
+`c4z/` (packaged drivers), `docs/` (generated PDFs) and `source/` (the squished
+per-driver Lua). `<repo>.zip` sits alongside them and contains all three.
 
 Step 1 rewrites tracked files in place. Formatting covers `tools/*.py`, all Lua
 under `drivers/`, `src/`, `test/`, `tools/` and `vendor/`, and every Markdown

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,30 @@ fmt-md: $(VENV_STAMP)
 	done; \
 	[ -z "$$files" ] || $(VENV_PY) -m mdformat --wrap 80 $$files
 
+# ─── Check ──────────────────────────────────────────────────────────────────
+# Assert-only mirror of fmt (--check, no rewrite); this is what CI runs.
+
+.PHONY: check check-lua check-py check-md
+check: check-lua check-py check-md ## Assert all code is formatted (no rewrite)
+
+check-lua:
+	@dirs=""; for d in ./drivers ./src ./test ./tools ./vendor; do \
+		[ -d "$$d" ] && dirs="$$dirs $$d"; \
+	done; \
+	[ -z "$$dirs" ] || stylua --check \
+		--indent-type Spaces --column-width 120 --line-endings Unix \
+		--indent-width 2 --quote-style AutoPreferDouble \
+		-g '*.lua' $$dirs
+
+check-py: $(VENV_STAMP)
+	$(VENV_BLACK) --check tools/*.py
+
+check-md: $(VENV_STAMP)
+	@files=""; for g in ./drivers/*/www/documentation/*.md documentation/*.md *.md; do \
+		[ -e "$$g" ] && files="$$files $$g"; \
+	done; \
+	[ -z "$$files" ] || $(VENV_PY) -m mdformat --check --wrap 80 $$files
+
 # ─── Preprocess ───────────────────────────────────────────────────────────────
 
 .PHONY: preprocess
@@ -167,14 +191,14 @@ docs-html: $(VENV_STAMP)
 
 docs-pdf: $(VENV_STAMP)
 	@for build in $(DISTRIBUTIONS); do \
-		mkdir -p "dist/$$build"; \
+		mkdir -p "dist/$$build/docs"; \
 		for driver_dir in build/$$build/drivers/*/; do \
 			if [ -f "$${driver_dir}.variant_pdf" ]; then \
 				driver_display_name=$$(cat "$${driver_dir}.variant_pdf"); \
 			else \
 				driver_display_name=$$($(VENV_PY) tools/package.py xml-get-name "$${driver_dir}driver.xml"); \
 			fi; \
-			pdf_output="dist/$$build/$$driver_display_name Documentation.pdf"; \
+			pdf_output="dist/$$build/docs/$$driver_display_name Documentation.pdf"; \
 			if [ -f "$$pdf_output" ]; then continue; fi; \
 			$(WEASYPRINT_ENV) $(VENV_PY) tools/docs.py html2pdf \
 				"$$(pwd)/$${driver_dir}www/documentation/index.html" \
@@ -185,24 +209,28 @@ docs-pdf: $(VENV_STAMP)
 # ─── Package ──────────────────────────────────────────────────────────────────
 
 .PHONY: package
+# The packager writes the .c4z into the output dir passed here (c4z/); the
+# squished .lua goes to source/ via the squishy Output path (see gen-squishy.lua),
+# so both subfolders are created up front.
 package: $(VENV_STAMP) $(PACKAGER) ## Create .c4z driver packages
 	@for build in $(DISTRIBUTIONS); do \
+		mkdir -p "dist/$$build/c4z" "dist/$$build/source"; \
 		for driver_dir in build/$$build/drivers/*/; do \
 			dir=$$(basename "$$driver_dir"); \
 			pwd_saved="$$(pwd)"; \
 			cd "build/$$build/drivers/$$dir" && \
-			"$$pwd_saved/$(VENV_PY)" "$$pwd_saved/$(PACKAGER)" . "$$pwd_saved/dist/$$build" driver.c4zproj && \
+			"$$pwd_saved/$(VENV_PY)" "$$pwd_saved/$(PACKAGER)" . "$$pwd_saved/dist/$$build/c4z" driver.c4zproj && \
 			cd "$$pwd_saved"; \
 		done; \
 	done
 
 .PHONY: zip
-zip: $(VENV_STAMP) ## Zip .c4z and .pdf files per distribution
+zip: $(VENV_STAMP) ## Zip the c4z/, docs/, and source/ subfolders per distribution
 	@repo="$$(basename "$$(pwd)")"; \
 	for build in $(DISTRIBUTIONS); do \
 		(cd "dist/$$build" && \
 			"$(CURDIR)/$(VENV_PY)" "$(CURDIR)/tools/package.py" zip \
-				"$$repo.zip" *.c4z *.pdf); \
+				"$$repo.zip" c4z docs source); \
 	done
 
 # ─── Test ─────────────────────────────────────────────────────────────────────

--- a/drivers/esphome/driver.lua
+++ b/drivers/esphome/driver.lua
@@ -22,7 +22,6 @@ require("lib.utils")
 require("drivers-common-public.global.handlers")
 require("drivers-common-public.global.lib")
 require("drivers-common-public.global.timer")
-require("drivers-common-public.global.url")
 
 local log = require("lib.logging")
 local bindings = require("lib.bindings")
@@ -151,8 +150,6 @@ function OnDriverLateInit()
   -- selection is persisted configuration, so it must not wait on the connect
   -- that detects proxy support.
   bluetoothProxyCapability:registerDeviceSelectionProperty()
-
-  C4:FileSetDir("c29tZXNwZWNpYWxrZXk=++11")
 
   -- Fire OnPropertyChanged to set the initial Headers and other Property
   -- global sets, they'll change if Property is changed.

--- a/drivers/esphome_bluetooth_coordinator/driver.lua
+++ b/drivers/esphome_bluetooth_coordinator/driver.lua
@@ -12,7 +12,6 @@ require("lib.utils")
 require("drivers-common-public.global.handlers")
 require("drivers-common-public.global.lib")
 require("drivers-common-public.global.timer")
-require("drivers-common-public.global.url")
 
 local log = require("lib.logging")
 local persist = require("lib.persist")

--- a/drivers/esphome_switchbot/driver.lua
+++ b/drivers/esphome_switchbot/driver.lua
@@ -8,7 +8,6 @@ require("lib.utils")
 require("drivers-common-public.global.handlers")
 require("drivers-common-public.global.lib")
 require("drivers-common-public.global.timer")
-require("drivers-common-public.global.url")
 
 JSON = require("JSON")
 

--- a/drivers/esphome_yale/driver.lua
+++ b/drivers/esphome_yale/driver.lua
@@ -9,7 +9,6 @@ require("lib.utils")
 require("drivers-common-public.global.handlers")
 require("drivers-common-public.global.lib")
 require("drivers-common-public.global.timer")
-require("drivers-common-public.global.url")
 
 JSON = require("JSON")
 

--- a/src/lib/bindings.lua
+++ b/src/lib/bindings.lua
@@ -5,6 +5,9 @@
 local log = require("lib.logging")
 local persist = require("lib.persist")
 
+require("drivers-common-public.global.lib")
+require("lib.utils")
+
 --- Create a binding between two devices if it doesn't already exist.
 --- @param idDeviceProvider integer Provider device ID
 --- @param idBindingProvider integer Provider binding ID

--- a/src/lib/conditionals.lua
+++ b/src/lib/conditionals.lua
@@ -3,6 +3,9 @@
 local log = require("lib.logging")
 local persist = require("lib.persist")
 
+require("drivers-common-public.global.lib")
+require("lib.utils")
+
 --- @class Conditionals
 --- A class representing conditionals.
 local Conditionals = {}

--- a/src/lib/events.lua
+++ b/src/lib/events.lua
@@ -4,6 +4,9 @@
 local log = require("lib.logging")
 local persist = require("lib.persist")
 
+require("drivers-common-public.global.lib")
+require("lib.utils")
+
 --- @class Events
 local Events = {}
 Events.__index = Events

--- a/src/lib/github-updater.lua
+++ b/src/lib/github-updater.lua
@@ -6,6 +6,9 @@ local log = require("lib.logging")
 local deferred = require("deferred")
 local version = require("version")
 
+require("lib.utils")
+require("drivers-common-public.global.lib")
+
 --- Utility class for updating drivers from GitHub releases.
 --- @class GitHubUpdater
 local GitHubUpdater = {}
@@ -138,6 +141,9 @@ function GitHubUpdater:downloadOutdatedDrivers(dir, repo, driverFilenames, inclu
         if downloadSize < 1 then
           return reject(string.format("asset %s download is empty", asset.name))
         end
+        -- GetDriverVersion only unlocks C4Z_ROOT for companion drivers, so a project running
+        -- one driver from this repo reaches the write with the alias still locked.
+        UnlockC4ZRoot()
         C4:FileSetDir(dir)
         local currentContents = C4:FileExists(asset.name) and FileRead(asset.name) or nil
         if FileWrite(asset.name, response.body, true) == -1 then

--- a/src/lib/http.lua
+++ b/src/lib/http.lua
@@ -4,6 +4,9 @@ local deferred = require("deferred")
 
 local log = require("lib.logging")
 
+require("drivers-common-public.global.url")
+require("lib.utils")
+
 --- Maximum timeout for HTTP requests.
 --- @type number
 local MAX_TIMEOUT = 300

--- a/src/lib/logging.lua
+++ b/src/lib/logging.lua
@@ -1,5 +1,7 @@
 --- A logging utility module for managing log levels and output modes.
 
+require("drivers-common-public.global.lib")
+
 --- A logging utility class with support for multiple log levels and output modes.
 --- @class Log
 --- @field _logName string The name of the log.

--- a/src/lib/persist.lua
+++ b/src/lib/persist.lua
@@ -25,6 +25,9 @@
 
 local log = require("lib.logging")
 
+require("drivers-common-public.global.lib")
+require("lib.utils")
+
 --- A utility class for storing and retrieving values from the controller's persistence store.
 --- @class Persist
 --- @field _persist table<string, any> A table to store the cached values.

--- a/src/lib/utils.lua
+++ b/src/lib/utils.lua
@@ -7,6 +7,10 @@ local lru = require("lib.lru")
 
 local constants = require("constants")
 
+require("drivers-common-public.global.lib")
+require("drivers-common-public.global.handlers")
+require("drivers-common-public.global.timer")
+
 --- @alias DeviceId integer|string
 
 do
@@ -78,12 +82,35 @@ function CheckMinimumVersion(statusProperty)
   return true
 end
 
+--- Undocumented hook: C4:FileSetDir rejects the C4Z_ROOT alias until this key is passed.
+--- Not every controller OS accepts the key, so it is pcall'd; a rejection then fails on the
+--- alias itself, as it did before this unlock, instead of erroring out of the caller.
+local C4Z_ROOT_UNLOCK_KEY = "c29tZXNwZWNpYWxrZXk=++11"
+
+--- Unlocks the C4Z_ROOT alias. Required before C4:FileSetDir can address any driver
+--- directory other than the running driver's own.
+function UnlockC4ZRoot()
+  pcall(function()
+    C4:FileSetDir(C4Z_ROOT_UNLOCK_KEY)
+  end)
+end
+
 --- Gets the version of a driver from its driver.xml file.
 --- @param filename string The filename of the driver.
 --- @return string|nil version The version of the driver, or nil if not found.
 function GetDriverVersion(filename)
   local basename, _ = filename:match("(.*)%.(.*)")
-  C4:FileSetDir("C4Z_ROOT", basename)
+  --- C4:GetDriverFileName is absent on some controller OS versions; without it every
+  --- filename takes the C4Z_ROOT path, which is what this function did previously.
+  local runningFilename = C4.GetDriverFileName and C4:GetDriverFileName()
+  local runningBasename = runningFilename and (runningFilename:match("(.*)%.(.*)") or runningFilename)
+  if basename ~= nil and basename == runningBasename then
+    --- The C4Z alias resolves to the running driver's own directory and needs no unlock.
+    C4:FileSetDir("C4Z")
+  else
+    UnlockC4ZRoot()
+    C4:FileSetDir("C4Z_ROOT", basename)
+  end
   return Select(ParseXml(FileRead("driver.xml")) or {}, "devicedata", "version") or nil
 end
 

--- a/src/lib/values.lua
+++ b/src/lib/values.lua
@@ -4,6 +4,10 @@ local log = require("lib.logging")
 local persist = require("lib.persist")
 local constants = require("constants")
 
+require("drivers-common-public.global.lib")
+require("drivers-common-public.global.handlers")
+require("lib.utils")
+
 --- @class Values
 --- @field _callbacks table<string, function?> In-memory registry of OVC callbacks keyed by variable name.
 --- A class representing a collection of named values with optional variable/property support.

--- a/test/c4_shim.lua
+++ b/test/c4_shim.lua
@@ -15,6 +15,7 @@ end
 -- Global C4 object shim
 C4 = {}
 Properties = {}
+Variables = {}
 
 -- Stub C4 functions that are called but not needed for testing
 function C4:GetDriverConfigInfo()
@@ -32,19 +33,103 @@ end
 function C4:AllowExecute() end
 function C4:UpdateProperty() end
 function C4:SetPropertyAttribs() end
+-- url.lua parses .version at load time; a non-numeric stub selects the pre-OS-3.0 path.
 function C4:GetVersionInfo()
-  return { version = "test" }
+  return { version = "4.2.1.757028-res", builddate = "2026-06-11", buildtime = "23:35:14", buildtype = "" }
 end
-function C4:FileSetDir() end
+-- Returns the running driver's filename, extension included.
+function C4:GetDriverFileName()
+  return "example.c4z"
+end
+-- Mirrors the controller: C4Z_ROOT errors until unlocked with the key below, and
+-- every other argument is a no-op.
+local FILE_SET_DIR_UNLOCK_KEY = "c29tZXNwZWNpYWxrZXk=++11"
+local c4zRootUnlocked = false
+function C4:FileSetDir(dir)
+  if dir == FILE_SET_DIR_UNLOCK_KEY then
+    c4zRootUnlocked = true
+  elseif dir == "C4Z_ROOT" and not c4zRootUnlocked then
+    error("Invalid alias: C4Z_ROOT", 2)
+  end
+end
 function C4:SendToDevice() end
 function C4:SendToProxy() end
-function C4:SendToNetwork() end
+
+---------------------------------------------------------------------------
+-- Network bindings
+-- Recorded rather than dropped, so a test can assert what a driver opened and
+-- sent without defining these itself. C4:GetBindingAddress is the controller's
+-- own accessor for the address; the frame log has no controller equivalent, so
+-- ShimSentFrames stands in and is named to be unmistakable.
+---------------------------------------------------------------------------
+
+local binding_address = {}
+local binding_port = {}
+local sent_frames = {}
+
+function C4:CreateNetworkConnection(binding, host, _type)
+  binding_address[binding] = host
+end
+
+function C4:GetBindingAddress(binding)
+  return binding_address[binding] or ""
+end
+
+-- Deliberately a no-op: the controller re-resolves the host and re-populates
+-- the address, so clearing it here would model a slot being freed that is not.
+function C4:SetBindingAddress() end
+
+function C4:NetPortOptions(binding, port, _type, _options)
+  binding_port[binding] = port
+end
+
+function C4:NetConnect() end
+function C4:NetDisconnect() end
+
+function C4:SendToNetwork(binding, port, data)
+  sent_frames[#sent_frames + 1] = { binding = binding, port = port, data = data }
+end
+
+--- @return table frames Every frame passed to C4:SendToNetwork, in order.
+function ShimSentFrames()
+  return sent_frames
+end
+
+--- @return table addresses, table ports Keyed by binding id.
+function ShimNetworkBindings()
+  return binding_address, binding_port
+end
+
+local function clear(t)
+  for k in pairs(t) do
+    t[k] = nil
+  end
+end
+
+--- Clear the recorded bindings, leaving the frame log alone. Separate from
+--- ShimResetSentFrames because a test that frees bindings mid-run is usually
+--- still counting frames across that point. Cleared in place so a table a test
+--- already holds stays the live one.
+function ShimResetBindings()
+  clear(binding_address)
+  clear(binding_port)
+end
+
+--- Clear the recorded frames.
+function ShimResetSentFrames()
+  clear(sent_frames)
+end
 function C4:SendUIRequest()
   return ""
 end
 function C4:GetBindingsByDevice()
   return {}
 end
+function C4:RegisterVariableListener() end
+function C4:UnregisterVariableListener() end
+function C4:UnregisterAllVariableListeners() end
+function C4:RegisterDeviceEvent() end
+function C4:UnregisterDeviceEvent() end
 function C4:FileExists()
   return false
 end
@@ -162,19 +247,240 @@ function C4:UUID(prefix)
   return string.format("%s-%d-%d", prefix or "UUID", os.time(), uuid_counter)
 end
 
--- Persistence stubs (in-memory storage for testing)
+---------------------------------------------------------------------------
+-- Variables
+-- Mirrors the controller rather than accommodating callers: values are always
+-- strings, updates are synchronous, and nothing is coerced or auto-created.
+-- test/test_c4_shim.lua pins each behaviour, measured on a dev controller.
+---------------------------------------------------------------------------
+
+-- Accepted on hardware. The controller's error message names only four types.
+-- Each maps to the code C4:GetDeviceVariables reports, measured one varType at
+-- a time: NUMBER and INT share 2, and nothing observed reports 7.
+local var_type_codes = {
+  STRING = 1,
+  INT = 2,
+  NUMBER = 2,
+  FLOAT = 3,
+  BOOL = 4,
+  LEVEL = 5,
+  STATE = 6,
+  TIME = 8,
+  ROOM = 9,
+  MEDIA = 10,
+  LIST = 11,
+  ULONG = 12,
+  XML = 13,
+  DEVICE = 14,
+}
+
+-- Director numbers each device's variables from 1001 and never reuses an id, so
+-- a deleted name returns at the end of the range. lib/values.lua restores hidden
+-- placeholders to keep that range stable, which is what makes ids worth modelling.
+local next_variable_id = 1001
+
+--- Id and attributes per variable name, behind C4:GetDeviceVariables. The value
+--- is read from Variables at call time so a SetVariable needs no bookkeeping here.
+--- @type table<string, { id: string, type: string, readonly: string, hidden: string }>
+local variable_meta = {}
+
+-- Strings and numbers only; nil means the controller would reject the value.
+local function var_value(value)
+  if type(value) == "string" then
+    return value
+  elseif type(value) == "number" then
+    return tostring(value)
+  end
+end
+
+-- Checks run in the controller's order: the value, then that varType is a
+-- string, then the existing-name return, and only then whether varType names a
+-- real type. An existing name returns false without ever validating varType.
+function C4:AddVariable(name, value, varType, readOnly, hidden)
+  local strValue = var_value(value)
+  if strValue == nil then
+    error("strValue should be a string", 2)
+  end
+  if type(varType) ~= "string" then
+    error("strVarType should be a string", 2)
+  end
+
+  name = tostring(name)
+
+  -- Already present: the controller keeps the existing value and type
+  if Variables[name] ~= nil then
+    return false
+  end
+
+  if not var_type_codes[varType] then
+    error("Invalid variable type.  Valid types include: BOOL, LEVEL, NUMBER, STRING.", 2)
+  end
+
+  Variables[name] = strValue
+  variable_meta[name] = {
+    id = tostring(next_variable_id),
+    type = tostring(var_type_codes[varType]),
+    readonly = readOnly == true and "True" or "False",
+    hidden = hidden == true and "True" or "False",
+  }
+  next_variable_id = next_variable_id + 1
+  return true
+end
+
+-- The value is checked before the name is looked up, so a bad value raises even
+-- on a name that was never added.
+function C4:SetVariable(name, value)
+  local strValue = var_value(value)
+  if strValue == nil then
+    error("strValue should be a string", 2)
+  end
+  name = tostring(name)
+
+  -- Never added: silently does nothing, and does not create it
+  if Variables[name] == nil then
+    return
+  end
+
+  Variables[name] = strValue
+end
+
+function C4:DeleteVariable(name)
+  name = tostring(name)
+  Variables[name] = nil
+  variable_meta[name] = nil
+end
+
+-- Keyed by id as a string, with every field a string: `type` is a numeric code,
+-- `readonly` and `hidden` are "True"/"False", and `description` is always empty
+-- because AddVariable cannot set one. A device with no variables and a device
+-- that does not exist both give an empty table, and hidden variables are
+-- returned rather than filtered out.
+---------------------------------------------------------------------------
+-- Project devices
+-- C4:GetDevices / GetDeviceDisplayName / GetDeviceVariables read a registry a
+-- test populates with ShimSetDevices. An id absent from it is the nameless,
+-- unresolvable case: GetDeviceDisplayName returns no value (arity 0, not nil),
+-- which is what the controller does and what a driver must tolerate.
+---------------------------------------------------------------------------
+
+--- @type table<number, table>
+local shim_devices = {}
+
+--- @param devices table<number, table> id -> { deviceName?, driverFileName?, roomId?, roomName?, variables?, hidden? }
+function ShimSetDevices(devices)
+  shim_devices = devices or {}
+end
+
+function ShimResetDevices()
+  shim_devices = {}
+end
+
+--- Take a device out of every lookup, modelling a transient resolution failure.
+function ShimSetDeviceHidden(deviceId, hidden)
+  local device = shim_devices[tonumber(deviceId)]
+  if device then
+    device.hidden = hidden and true or nil
+  end
+end
+
+function C4:GetDevices(filter)
+  local deviceId = tonumber(filter and filter.DeviceIds)
+  local device = deviceId ~= nil and shim_devices[deviceId] or nil
+  if device == nil or device.hidden then
+    return {}
+  end
+  if filter.C4iNames ~= nil then
+    local matched = false
+    for c4iName in string.gmatch(filter.C4iNames, "([^,]+)") do
+      if c4iName == device.driverFileName then
+        matched = true
+        break
+      end
+    end
+    if not matched then
+      return {}
+    end
+  end
+  return { [deviceId] = device }
+end
+
+function C4:GetDeviceDisplayName(deviceId)
+  local device = shim_devices[tonumber(deviceId)]
+  if device and not device.hidden and device.deviceName ~= nil then
+    return device.deviceName
+  end
+  -- Absent or nameless: return no value, matching the controller.
+end
+
+function C4:GetDeviceVariables(deviceId)
+  local device = shim_devices[tonumber(deviceId)]
+  if device and device.variables then
+    return device.variables
+  end
+  -- The running driver's own variables, as created through C4:AddVariable.
+  local variables = {}
+  if tonumber(deviceId) == tonumber(C4:GetDeviceID()) then
+    for name, meta in pairs(variable_meta) do
+      variables[meta.id] = {
+        name = name,
+        description = "",
+        value = Variables[name],
+        type = meta.type,
+        readonly = meta.readonly,
+        hidden = meta.hidden,
+      }
+    end
+  end
+  return variables
+end
+
+-- The C4:Persist* SDK methods, backed by an in-memory store. The bare
+-- PersistGetValue/SetValue/DeleteValue globals belong to global/lib.lua, whose
+-- wrappers delegate here when C4.PersistSetValue exists; stubbing the globals
+-- instead would be paved over the moment any module requires global.lib.
 local persist_store = {}
 
-function PersistGetValue(key, encrypted)
+function C4:PersistGetValue(key, encrypted)
   return persist_store[key]
 end
 
-function PersistSetValue(key, value, encrypted)
+function C4:PersistSetValue(key, value, encrypted)
   persist_store[key] = value
 end
 
-function PersistDeleteValue(key)
+function C4:PersistDeleteValue(key)
   persist_store[key] = nil
+end
+
+---------------------------------------------------------------------------
+-- Timer handles
+-- A controller returns userdata from C4:SetTimer, and global/timer.lua only
+-- resolves a handle when `type(timerId) == "userdata"`, so a table handle
+-- makes every CancelTimer a silent no-op under test. newproxy(true) is the
+-- only way to mint userdata from Lua; LuaJIT keeps it.
+---------------------------------------------------------------------------
+
+local timer_handle_count = 0
+
+--- @param cancel fun(): nil Invoked by handle:Cancel().
+--- @return userdata handle A stand-in for the controller's C4LuaTimer.
+local function new_timer_handle(cancel)
+  timer_handle_count = timer_handle_count + 1
+  local serial = timer_handle_count
+  local handle = newproxy(true)
+  local mt = getmetatable(handle)
+  mt.__index = {
+    Cancel = function()
+      cancel()
+      -- Returns nil, so global/timer.lua clears its slot on cancel
+      return nil
+    end,
+  }
+  -- Distinct per handle, like the controller's address-bearing rendering
+  mt.__tostring = function()
+    return string.format("C4LuaTimer (shim #%d)", serial)
+  end
+  return handle
 end
 
 ---------------------------------------------------------------------------
@@ -182,53 +488,80 @@ end
 -- Only available when luasocket is installed.
 ---------------------------------------------------------------------------
 
-if has_socket then
-  --- Timer implementation using socket.gettime
-  local timers = {}
-  local timer_id = 0
+local timers = {}
+local timer_id = 0
 
-  function C4:SetTimer(delay_ms, callback, repeating)
-    timer_id = timer_id + 1
-    local id = timer_id
+local function clock()
+  return has_socket and socket.gettime() or 0
+end
 
-    local handle = {
-      id = id,
-      Cancel = function(self)
-        if timers[id] then
-          timers[id].cancelled = true
-          timers[id] = nil
-        end
-      end,
-    }
+function C4:SetTimer(delay_ms, callback, repeating)
+  timer_id = timer_id + 1
+  local id = timer_id
 
-    local timer = {
-      id = id,
-      delay = delay_ms / 1000,
-      callback = callback,
-      repeating = repeating or false,
-      next_fire = socket.gettime() + (delay_ms / 1000),
-      cancelled = false,
-      handle = handle,
-    }
+  local handle = new_timer_handle(function()
+    if timers[id] then
+      timers[id].cancelled = true
+      timers[id] = nil
+    end
+  end)
 
-    timers[id] = timer
-    return handle
+  timers[id] = {
+    id = id,
+    delay = delay_ms / 1000,
+    callback = callback,
+    repeating = repeating or false,
+    next_fire = clock() + (delay_ms / 1000),
+    cancelled = false,
+    handle = handle,
+  }
+  return handle
+end
+
+--- Fire whatever the clock says is due. Without luasocket there is no clock, so
+--- nothing is ever due and ShimFireTimers is the only way to drive a timer.
+function C4:ProcessTimers()
+  if not has_socket then
+    return
   end
-
-  function C4:ProcessTimers()
-    local now = socket.gettime()
-    for id, timer in pairs(timers) do
-      if not timer.cancelled and now >= timer.next_fire then
-        timer.callback(timer.handle, 0)
-        if timer.repeating then
-          timer.next_fire = now + timer.delay
-        else
-          timers[id] = nil
-        end
+  local now = socket.gettime()
+  for id, timer in pairs(timers) do
+    if not timer.cancelled and now >= timer.next_fire then
+      timer.callback(timer.handle, 0)
+      if timer.repeating then
+        timer.next_fire = now + timer.delay
+      else
+        timers[id] = nil
       end
     end
   end
+end
 
+--- Harness, not a controller API: fire every pending timer now regardless of its
+--- delay, so a test can drive a long timeout without waiting for it. Works on
+--- both branches, which is what lets a test avoid defining its own SetTimer.
+--- The slot is cleared before the callback runs, so a callback that re-arms the
+--- same timer is not immediately fired again.
+function ShimFireTimers()
+  local due = {}
+  for id, timer in pairs(timers) do
+    if not timer.cancelled then
+      due[id] = timer
+    end
+  end
+  for id, timer in pairs(due) do
+    if timers[id] then
+      if timer.repeating then
+        timer.next_fire = clock() + timer.delay
+      else
+        timers[id] = nil
+      end
+      timer.callback(timer.handle, 0)
+    end
+  end
+end
+
+if has_socket then
   --- TCP Client implementation
   local TCPClient = {}
   TCPClient.__index = TCPClient
@@ -362,11 +695,11 @@ if has_socket then
     end
   end
 
-  function sleep(seconds)
+  function ShimSleep(seconds)
     socket.sleep(seconds)
   end
 
-  function processEventLoop()
+  function ShimProcessEventLoop()
     C4:ProcessTimers()
     for _, client in pairs(active_clients) do
       if client.DoRead then
@@ -376,19 +709,13 @@ if has_socket then
   end
 
   --- Run the event loop until os.exit() or signal.
-  function runEventLoop()
+  function ShimRunEventLoop()
     while true do
-      processEventLoop()
+      ShimProcessEventLoop()
       socket.sleep(0.01)
     end
   end
 else
-  -- Stub timer that does nothing (sufficient for module loading)
-  function C4:SetTimer(delay_ms, callback, repeating)
-    return { Cancel = function() end }
-  end
-
-  function C4:ProcessTimers() end
   function C4:CreateTCPClient()
     return setmetatable({}, {
       __index = function()
@@ -397,9 +724,20 @@ else
     })
   end
 
-  function sleep() end
-  function processEventLoop() end
-  function runEventLoop() end
+  function ShimSleep() end
+  function ShimProcessEventLoop() end
+  function ShimRunEventLoop() end
+end
+
+-- Mirrors the controller rather than accommodating callers. Measured on a dev
+-- controller: C4:SetTimer returns userdata carrying :Cancel(), C4:AddTimer
+-- returns a number, and C4:KillTimer takes that number. Passing a SetTimer
+-- handle raises "idTimer should be a number", so this does too: a shim that
+-- accepted it would let a call that fails on hardware pass in tests.
+function C4:KillTimer(idTimer)
+  if type(idTimer) ~= "number" then
+    error("idTimer should be a number", 2)
+  end
 end
 
 print("C4 shim layer loaded" .. (has_socket and " (with luasocket)" or " (stubs only)"))

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -1,39 +1,20 @@
 #!/bin/bash
-# Wrapper script to run ESPHome tests with proper environment
+# Run a single test file under the C4 shim, the way `make test` runs the suite.
 #
 # Usage:
-#   ./run_test.sh <test_file> [options]
-#   ./run_test.sh <test_file> --ip <ip> [--password <pwd> | --key <encryption_key>] [--timeout <seconds>]
+#   ./run_test.sh <test_file> [--timeout <seconds>]
 #
-# Examples:
-#   ./run_test.sh test_fatal_error.lua --ip 192.168.1.100
-#   ./run_test.sh test_esphome_connection.lua --ip 192.168.1.100 --password MyPassword
-#   ./run_test.sh test_esphome_connection.lua --ip 192.168.1.100 --key BASE64_ENCRYPTION_KEY --timeout 10
+# Example:
+#   ./run_test.sh test_http_redact.lua
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Parse arguments
 TEST_FILE=""
-IP_ADDRESS=""
-PASSWORD=""
-ENCRYPTION_KEY=""
-TIMEOUT=5
+TIMEOUT=""
 
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --ip)
-      IP_ADDRESS="$2"
-      shift 2
-      ;;
-    --password)
-      PASSWORD="$2"
-      shift 2
-      ;;
-    --key)
-      ENCRYPTION_KEY="$2"
-      shift 2
-      ;;
     --timeout)
       TIMEOUT="$2"
       shift 2
@@ -48,37 +29,30 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ -z "$TEST_FILE" ]; then
-  echo "Error: test file is required"
-  echo ""
-  echo "Usage: $0 <test_file> [--ip <ip>] [--password <pwd> | --key <key>] [--timeout <seconds>]"
-  echo ""
-  echo "Examples:"
-  echo "  $0 test_fatal_error.lua --ip 192.168.1.100"
-  echo "  $0 test_esphome_connection.lua --ip 192.168.1.100 --password MyPassword"
+  echo "Usage: $0 <test_file> [--timeout <seconds>]" >&2
   exit 1
 fi
 
-# Add luarocks paths first if available (sets LUA_PATH/LUA_CPATH)
-if command -v luarocks &> /dev/null; then
-  eval $(luarocks path --bin 2>/dev/null)
+# Pick up luarocks-installed modules (e.g. luasocket) if present.
+if command -v luarocks &>/dev/null; then
+  eval "$(luarocks path --bin 2>/dev/null)"
 fi
 
-# Prepend project source, vendor, and test shim paths
 export LUA_PATH="${SCRIPT_DIR}/?.lua;${PROJECT_ROOT}/src/?.lua;${PROJECT_ROOT}/src/?/init.lua;${PROJECT_ROOT}/vendor/?.lua;${PROJECT_ROOT}/vendor/?/init.lua;${LUA_PATH:-}"
 
-# Export config as environment variables for the Lua scripts
-export ESPHOME_TEST_IP="$IP_ADDRESS"
-export ESPHOME_TEST_PASSWORD="$PASSWORD"
-export ESPHOME_TEST_KEY="$ENCRYPTION_KEY"
+cd "$SCRIPT_DIR" || exit 1
+PRELUDE="io.stdout:setvbuf('no'); io.stderr:setvbuf('no'); require('c4_shim')"
 
-# Run the test with LuaJIT, loading the C4 shim before the test file
-cd "$SCRIPT_DIR"
-timeout ${TIMEOUT} luajit -e "io.stdout:setvbuf('no'); io.stderr:setvbuf('no'); require('c4_shim')" "$TEST_FILE"
-
-EXIT_CODE=$?
-if [ $EXIT_CODE -eq 124 ]; then
-  echo ""
-  echo "Test timed out after ${TIMEOUT} seconds"
+if [ -n "$TIMEOUT" ]; then
+  timeout "$TIMEOUT" luajit -e "$PRELUDE" "$TEST_FILE"
+  EXIT_CODE=$?
+  if [ $EXIT_CODE -eq 124 ]; then
+    echo "" >&2
+    echo "Test timed out after ${TIMEOUT} seconds" >&2
+  fi
+else
+  luajit -e "$PRELUDE" "$TEST_FILE"
+  EXIT_CODE=$?
 fi
 
 exit $EXIT_CODE

--- a/test/test_c4_shim.lua
+++ b/test/test_c4_shim.lua
@@ -1,0 +1,544 @@
+-- Tests for test/c4_shim.lua itself.
+--
+-- Every place the shim diverges from a controller is a place a test can go
+-- green on a call that fails, or does nothing, on hardware. Two are pinned
+-- here: C4:SetTimer must return userdata, or global/timer.lua CancelTimer
+-- silently no-ops; and the C4 variable API must exist and behave the way
+-- Director does, or lib/values.lua is unusable in a test. Expectations were
+-- measured on a dev controller, not inferred from the shim.
+--
+-- Run from the template root:
+--   LUA_PATH="$PWD/test/?.lua;$PWD/src/?.lua;$PWD/vendor/?.lua;$PWD/vendor/?/init.lua;;" \
+--     luajit -e "require('c4_shim')" test/test_c4_shim.lua
+
+local pass, fail = 0, 0
+local function check(name, ok, detail)
+  if ok then
+    pass = pass + 1
+    print(string.format("  ok   %s", name))
+  else
+    fail = fail + 1
+    print(string.format("  FAIL %s%s", name, detail and ("  -> " .. tostring(detail)) or ""))
+  end
+end
+
+local function section(name)
+  print("\n[" .. name .. "]")
+end
+
+--- Assert that fn() raises, and that the message ends with `expected`. The
+--- controller's messages arrive unprefixed; Lua prepends "file:line:".
+local function raises(fn, expected)
+  local ok, err = pcall(fn)
+  if ok then
+    return false, "did not raise"
+  end
+  err = tostring(err)
+  if expected and not err:find(expected, 1, true) then
+    return false, "raised " .. err
+  end
+  return true
+end
+
+--- Assert that fn() raises, and that the message points at the line that called
+--- the shim rather than at a line inside it.
+local function raises_at_caller(fn)
+  local ok, err = pcall(fn)
+  if ok then
+    return false, "did not raise"
+  end
+  err = tostring(err)
+  if not err:find("test_c4_shim.lua:", 1, true) then
+    return false, "raised " .. err
+  end
+  return true
+end
+
+local function clearVariables()
+  for name in pairs(Variables) do
+    C4:DeleteVariable(name)
+  end
+end
+
+--- The variable of the given name as C4:GetDeviceVariables reports it, plus its
+--- id. Director keys by id rather than by name, so a name lookup is a scan.
+local function variableByName(name)
+  for id, variable in pairs(C4:GetDeviceVariables(C4:GetDeviceID())) do
+    if variable.name == name then
+      return variable, id
+    end
+  end
+end
+
+--- One field of a variable, or nil if the name is absent. Indexing the record
+--- directly turns a missing variable into an error that ends the run, and a run
+--- that ended early is hard to tell from one that passed.
+local function variableField(name, field)
+  local variable = variableByName(name)
+  return variable and variable[field]
+end
+
+--------------------------------------------------------------------------------
+section("C4:AddVariable")
+--------------------------------------------------------------------------------
+
+clearVariables()
+
+check("returns true when it creates the variable", C4:AddVariable("Temp", "21.5", "NUMBER", true, false) == true)
+check("populates Variables synchronously", Variables["Temp"] == "21.5")
+check("stores the value as a string", type(Variables["Temp"]) == "string")
+
+-- Nothing has been added before this point, so this is the first id the shim
+-- hands out. Director starts a device's own variables at 1001.
+local tempId = select(2, variableByName("Temp"))
+check("numbers the first variable 1001", tempId == "1001", tempId)
+check("keys by id as a string", type(tempId) == "string")
+check(
+  "records readOnly as a capitalised string",
+  variableField("Temp", "readonly") == "True",
+  variableField("Temp", "readonly")
+)
+check(
+  "records the varType as a numeric code in a string",
+  variableField("Temp", "type") == "2",
+  variableField("Temp", "type")
+)
+check("reports the value", variableField("Temp", "value") == "21.5")
+check("reports an empty description", variableField("Temp", "description") == "")
+
+check("returns false when the name already exists", C4:AddVariable("Temp", "99", "NUMBER", true, false) == false)
+check("a repeat add leaves the value alone", Variables["Temp"] == "21.5")
+check("a repeat add leaves the type alone", variableField("Temp", "type") == "2")
+check("a repeat add does not consume an id", select(2, variableByName("Temp")) == "1001")
+
+C4:AddVariable("Count", 7, "INT", true, false)
+check("accepts a number and stores tostring of it", Variables["Count"] == "7")
+
+C4:AddVariable("Hidden", "x", "STRING", true, true)
+check("records hidden as a capitalised string", variableField("Hidden", "hidden") == "True")
+check("a hidden variable still appears in Variables", Variables["Hidden"] == "x")
+-- Director returns hidden variables rather than omitting them, so a caller that
+-- wants them gone has to read this field and skip on it.
+check("a hidden variable is still returned by GetDeviceVariables", variableByName("Hidden") ~= nil)
+
+C4:AddVariable("Defaults", "x", "STRING")
+check("readOnly defaults to False", variableField("Defaults", "readonly") == "False")
+check("hidden defaults to False", variableField("Defaults", "hidden") == "False")
+
+C4:AddVariable(98765, "x", "STRING", true, false)
+check("coerces a non-string name", Variables["98765"] == "x")
+
+-- lib/values.lua reads "0"/"1" back from a BOOL because it wrote "0"/"1", not
+-- because Director coerces.
+C4:AddVariable("Raw", "true", "BOOL", true, false)
+check("does not normalise a BOOL value", Variables["Raw"] == "true")
+
+check(
+  "raises on a boolean value",
+  raises(function()
+    C4:AddVariable("Bad", true, "BOOL", true, false)
+  end, "strValue should be a string")
+)
+check(
+  "raises on a nil value",
+  raises(function()
+    C4:AddVariable("Bad", nil, "STRING", true, false)
+  end, "strValue should be a string")
+)
+check("a rejected add creates nothing", Variables["Bad"] == nil)
+
+check(
+  "raises on a nil varType",
+  raises(function()
+    C4:AddVariable("Bad", "x", nil, true, false)
+  end, "strVarType should be a string")
+)
+check(
+  "raises on an unknown varType",
+  raises(function()
+    C4:AddVariable("Bad", "x", "DYNAMIC", true, false)
+  end, "Invalid variable type.")
+)
+
+-- Each case above breaks one rule, which leaves the order between them free.
+check(
+  "the value is checked before an unknown varType",
+  raises(function()
+    C4:AddVariable("Bad", true, "DYNAMIC", true, false)
+  end, "strValue should be a string")
+)
+check(
+  "the value is checked before a nil varType",
+  raises(function()
+    C4:AddVariable("Bad", true, nil, true, false)
+  end, "strValue should be a string")
+)
+local repeatOk, repeatRet = pcall(function()
+  return C4:AddVariable("Temp", "x", "DYNAMIC", true, false)
+end)
+check("an existing name returns false without validating varType", repeatOk and repeatRet == false, repeatRet)
+check(
+  "an existing name still checks the value",
+  raises(function()
+    C4:AddVariable("Temp", true, "NUMBER", true, false)
+  end, "strValue should be a string")
+)
+check(
+  "an existing name still checks that varType is a string",
+  raises(function()
+    C4:AddVariable("Temp", "x", nil, true, false)
+  end, "strVarType should be a string")
+)
+check("a rejected repeat add leaves the value alone", Variables["Temp"] == "21.5")
+
+check(
+  "a rejected add blames the caller, not the shim",
+  raises_at_caller(function()
+    C4:AddVariable("Bad", true, "STRING", true, false)
+  end)
+)
+
+-- The controller's error message names four types but accepts all of these. The
+-- code each reports was measured by adding one variable per varType on a dev
+-- controller and dumping C4:GetDeviceVariables. Two results worth stating: the
+-- mapping is not 1:1, and no varType produced 7.
+for _, case in ipairs({
+  { "STRING", "1" },
+  { "INT", "2" },
+  { "NUMBER", "2" },
+  { "FLOAT", "3" },
+  { "BOOL", "4" },
+  { "LEVEL", "5" },
+  { "STATE", "6" },
+  { "TIME", "8" },
+  { "ROOM", "9" },
+  { "MEDIA", "10" },
+  { "LIST", "11" },
+  { "ULONG", "12" },
+  { "XML", "13" },
+  { "DEVICE", "14" },
+}) do
+  local varType, code = case[1], case[2]
+  local ok = pcall(function()
+    C4:AddVariable("Type_" .. varType, "1", varType, true, false)
+  end)
+  check("accepts varType " .. varType, ok and Variables["Type_" .. varType] == "1")
+  local variable = variableByName("Type_" .. varType)
+  check(
+    "reports varType " .. varType .. " as type " .. code,
+    variable and variable.type == code,
+    variable and variable.type
+  )
+end
+
+check(
+  "NUMBER and INT collapse onto one code",
+  variableField("Type_NUMBER", "type") == variableField("Type_INT", "type")
+)
+
+--------------------------------------------------------------------------------
+section("C4:SetVariable")
+--------------------------------------------------------------------------------
+
+clearVariables()
+C4:AddVariable("Temp", "21.5", "NUMBER", true, false)
+
+C4:SetVariable("Temp", "22.0")
+check("updates Variables synchronously", Variables["Temp"] == "22.0")
+check("the new value is visible through GetDeviceVariables", variableField("Temp", "value") == "22.0")
+
+C4:SetVariable("Temp", 5)
+check("accepts a number and stores tostring of it", Variables["Temp"] == "5")
+
+-- readOnly describes what C4 programming may do, not what the driver may do.
+C4:AddVariable("Locked", "0", "BOOL", true, false)
+C4:SetVariable("Locked", "1")
+check("writes through to a readOnly variable", Variables["Locked"] == "1")
+
+C4:SetVariable("Locked", "false")
+check("does not normalise a BOOL value", Variables["Locked"] == "false")
+
+check(
+  "raises on a boolean value",
+  raises(function()
+    C4:SetVariable("Temp", true)
+  end, "strValue should be a string")
+)
+check(
+  "raises on a nil value",
+  raises(function()
+    C4:SetVariable("Temp", nil)
+  end, "strValue should be a string")
+)
+check("a rejected set leaves the value alone", Variables["Temp"] == "5")
+
+-- Silent, and specifically not a create: lib/values.lua relies on the
+-- add-vs-set split.
+local ok = pcall(function()
+  C4:SetVariable("NeverAdded", "hello")
+end)
+check("does not raise on an unknown name", ok)
+check("does not create an unknown name", Variables["NeverAdded"] == nil)
+
+-- The value is checked before the name is looked up, so an unknown name is only
+-- silent for a value the controller would have accepted.
+check(
+  "raises on a boolean value for an unknown name",
+  raises(function()
+    C4:SetVariable("NeverAdded", true)
+  end, "strValue should be a string")
+)
+check("a rejected set on an unknown name creates nothing", Variables["NeverAdded"] == nil)
+
+check(
+  "a rejected set blames the caller, not the shim",
+  raises_at_caller(function()
+    C4:SetVariable("Temp", true)
+  end)
+)
+
+--------------------------------------------------------------------------------
+section("C4:DeleteVariable")
+--------------------------------------------------------------------------------
+
+clearVariables()
+C4:AddVariable("Temp", "21.5", "NUMBER", true, false)
+local _, deletedId = variableByName("Temp")
+C4:DeleteVariable("Temp")
+check("clears Variables synchronously", Variables["Temp"] == nil)
+check("drops it from GetDeviceVariables", variableByName("Temp") == nil)
+check(
+  "does not raise on an unknown name",
+  pcall(function()
+    C4:DeleteVariable("NeverAdded")
+  end)
+)
+
+C4:AddVariable("Temp", "1", "STRING", true, false)
+check("the name is reusable after a delete", Variables["Temp"] == "1")
+
+-- Ids come from a counter that a delete does not rewind. This is the behaviour
+-- lib/values.lua works around: it restores hidden placeholders for deleted
+-- values so the surviving ones keep their ids across a reset.
+local _, reusedId = variableByName("Temp")
+check("a re-added name gets a fresh id", reusedId ~= deletedId, reusedId)
+check("ids only ever increase", tonumber(reusedId) > tonumber(deletedId))
+
+--------------------------------------------------------------------------------
+section("C4:GetDeviceVariables")
+--------------------------------------------------------------------------------
+
+clearVariables()
+
+check("a device with no variables gives an empty table", next(C4:GetDeviceVariables(C4:GetDeviceID())) == nil)
+check("returns a table rather than nil", type(C4:GetDeviceVariables(C4:GetDeviceID())) == "table")
+
+C4:AddVariable("Scoped", "x", "STRING", false, false)
+check("returns this device's variables", variableByName("Scoped") ~= nil)
+-- A device id that does not exist is not an error on hardware, it is empty.
+check("an unknown device gives an empty table", next(C4:GetDeviceVariables(999999)) == nil)
+
+for _, field in ipairs({ "name", "description", "value", "type", "readonly", "hidden" }) do
+  check("every field is a string: " .. field, type(variableField("Scoped", field)) == "string")
+end
+
+-- Keying by id means a repeated id drops a variable from the table instead of
+-- reporting one, so the count is what catches it rather than any single lookup.
+C4:AddVariable("Second", "x", "STRING", false, false)
+C4:AddVariable("Third", "x", "STRING", false, false)
+local reported, tracked = 0, 0
+for _ in pairs(C4:GetDeviceVariables(C4:GetDeviceID())) do
+  reported = reported + 1
+end
+for _ in pairs(Variables) do
+  tracked = tracked + 1
+end
+check("every variable has a distinct id", reported == tracked, reported .. " reported, " .. tracked .. " added")
+
+--------------------------------------------------------------------------------
+section("lib/values.lua under the shim")
+--------------------------------------------------------------------------------
+
+require("drivers-common-public.global.handlers") -- OVC and the other handler tables
+require("drivers-common-public.global.lib") -- Select, Serialize, Deserialize
+require("lib.utils") -- IsEmpty, toboolean, tointeger
+
+clearVariables()
+
+-- lib.values is gated on lib_modules; a render without it is valid, not broken.
+local loaded, values
+if package.searchpath("lib.values", package.path) == nil then
+  print("  skip lib/values.lua is not in this render")
+else
+  loaded, values = pcall(require, "lib.values")
+  check("lib.values loads", loaded, values)
+end
+
+if loaded then
+  values:reset()
+
+  check("update creates the C4 variable", pcall(function()
+    values:update("Temperature", 21.5, "NUMBER")
+  end) and Variables["Temperature"] == "21.5")
+
+  values:update("Temperature", 22.5, "NUMBER")
+  check("a second update sets rather than re-adds", Variables["Temperature"] == "22.5")
+
+  values:update("Enabled", true, "BOOL")
+  check('a BOOL value reaches C4 as "1"', Variables["Enabled"] == "1")
+  values:update("Enabled", false, "BOOL")
+  check('a false BOOL value reaches C4 as "0"', Variables["Enabled"] == "0")
+
+  values:update("ReadOnly", "x", "STRING")
+  check("a value with no callback is created readOnly", variableField("ReadOnly", "readonly") == "True")
+
+  values:update("Writable", "x", "STRING", function() end)
+  check("a value with a callback is created writable", variableField("Writable", "readonly") == "False")
+  check("a callback is registered in OVC", type(OVC["Writable"]) == "function")
+
+  values:delete("Temperature")
+  check("delete removes the C4 variable", Variables["Temperature"] == nil)
+
+  values:reset()
+  check("reset removes every C4 variable", Variables["Enabled"] == nil and Variables["Writable"] == nil)
+end
+
+--------------------------------------------------------------------------------
+section("C4:SetTimer handles")
+--------------------------------------------------------------------------------
+
+--- Reload the shim with luasocket forced present or absent. The two branches
+--- define C4:SetTimer separately, and CI has no luasocket while a developer
+--- machine may, so both need the same handle shape.
+local function withShim(hasSocket, body)
+  local saved = {
+    C4 = C4,
+    Variables = Variables,
+    Properties = Properties,
+    socketLoaded = package.loaded["socket"],
+    socketPreload = package.preload["socket"],
+    shim = package.loaded["c4_shim"],
+    Timer = Timer,
+    TimerFunctions = TimerFunctions,
+  }
+
+  local now = 1000
+  package.loaded["socket"] = nil
+  if hasSocket then
+    package.preload["socket"] = function()
+      return {
+        gettime = function()
+          return now
+        end,
+        sleep = function() end,
+        tcp = function()
+          return nil
+        end,
+      }
+    end
+  else
+    package.preload["socket"] = function()
+      error("luasocket not installed")
+    end
+  end
+
+  package.loaded["c4_shim"] = nil
+  require("c4_shim")
+
+  -- global/timer.lua keeps its registries in globals, so reset them too
+  Timer, TimerFunctions = {}, {}
+
+  local ok, err = pcall(body, function(seconds)
+    now = now + (seconds or 1)
+    C4:ProcessTimers()
+  end)
+
+  package.loaded["socket"] = saved.socketLoaded
+  package.preload["socket"] = saved.socketPreload
+  package.loaded["c4_shim"] = saved.shim
+  -- The id counter and the attribute table are locals in the shim, so the reload
+  -- gets its own and restoring C4 restores the originals along with it.
+  C4, Variables, Properties = saved.C4, saved.Variables, saved.Properties
+  Timer, TimerFunctions = saved.Timer, saved.TimerFunctions
+
+  if not ok then
+    check("shim reload (luasocket " .. tostring(hasSocket) .. ")", false, err)
+  end
+end
+
+-- global/timer.lua logs through dbg when it is given a nil timerId.
+if type(dbg) ~= "function" then
+  function dbg() end
+end
+require("drivers-common-public.global.timer")
+
+check(
+  "C4:KillTimer blames the caller, not the shim",
+  raises_at_caller(function()
+    C4:KillTimer(C4:SetTimer(5000, function() end, false))
+  end)
+)
+
+for _, hasSocket in ipairs({ false, true }) do
+  local label = hasSocket and "with luasocket" or "without luasocket"
+
+  withShim(hasSocket, function(tick)
+    local handle = C4:SetTimer(5000, function() end, false)
+
+    check(label .. ": returns userdata", type(handle) == "userdata", type(handle))
+    check(label .. ": carries a Cancel method", type(handle.Cancel) == "function")
+    check(label .. ": Cancel returns nil", handle:Cancel() == nil)
+    check(
+      label .. ": Cancel is idempotent",
+      pcall(function()
+        handle:Cancel()
+      end)
+    )
+
+    local keyed = {}
+    keyed[C4:SetTimer(5000, function() end, false)] = "yes"
+    check(
+      label .. ": usable as a table key",
+      (function()
+        for k, v in pairs(keyed) do
+          return type(k) == "userdata" and v == "yes"
+        end
+      end)()
+    )
+
+    -- The defect itself: with a table handle nothing is cancelled and the
+    -- TimerFunctions entry leaks.
+    Timer, TimerFunctions = {}, {}
+    local fired = 0
+    local t = SetTimer("ping", 5000, function()
+      fired = fired + 1
+    end)
+
+    check(label .. ": SetTimer registers the handle", TimerFunctions[t] ~= nil)
+    check(label .. ": SetTimer records the named slot", Timer["ping"] == t)
+
+    local returned = CancelTimer(t)
+    check(label .. ": CancelTimer returns nil", returned == nil)
+    check(label .. ": CancelTimer drops TimerFunctions", TimerFunctions[t] == nil)
+    check(label .. ": CancelTimer drops the named slot", Timer["ping"] == nil)
+
+    if hasSocket then
+      tick(10)
+      check(label .. ": a cancelled callback does not fire", fired == 0, fired)
+
+      -- Or the assertion above would pass for the wrong reason
+      Timer, TimerFunctions = {}, {}
+      local ran = 0
+      SetTimer("live", 1000, function()
+        ran = ran + 1
+      end)
+      tick(10)
+      check(label .. ": an uncancelled callback fires", ran == 1, ran)
+    end
+  end)
+end
+
+--------------------------------------------------------------------------------
+
+print(string.format("\n%d passed, %d failed", pass, fail))
+os.exit(fail == 0 and 0 or 1)

--- a/test/test_device_id_list.lua
+++ b/test/test_device_id_list.lua
@@ -40,47 +40,9 @@ local PROJECT = {
   [400] = { deviceName = "Desk Lamp", driverFileName = "light_v2.c4i", roomId = "1", roomName = "Office" },
 }
 
---- @type table<integer, boolean>
-local hidden = {}
-
-C4 = C4 or {}
-
-function C4:GetDevices(filter)
-  local deviceId = tonumber(filter and filter.DeviceIds)
-  local device = deviceId ~= nil and not hidden[deviceId] and PROJECT[deviceId] or nil
-  if device == nil then
-    return {}
-  end
-  if filter.C4iNames ~= nil then
-    local matched = false
-    for c4iName in string.gmatch(filter.C4iNames, "([^,]+)") do
-      if c4iName == device.driverFileName then
-        matched = true
-        break
-      end
-    end
-    if not matched then
-      return {}
-    end
-  end
-  return { [deviceId] = device }
-end
-
-function C4:GetDeviceDisplayName(deviceId)
-  deviceId = tonumber(deviceId)
-  local device = deviceId ~= nil and not hidden[deviceId] and PROJECT[deviceId] or nil
-  return device and device.deviceName or ""
-end
-
---- `src/constants.lua` is driver-specific, so it does not exist in the template
---- itself and `make test` cannot load utils.lua in a bare render. utils.lua
---- reads only HIDE_PROPERTY / SHOW_PROPERTY from it, in CheckMinimumVersion,
---- which this suite never calls -- so stub it unconditionally rather than
---- branching on whether a real one is present. Branching would let the same
---- source report two different truths depending on where it is checked out.
-package.preload["constants"] = function()
-  return { SHOW_PROPERTY = 0, HIDE_PROPERTY = 1 }
-end
+-- The shim owns C4:GetDevices / GetDeviceDisplayName, reading this project.
+require("c4_shim")
+ShimSetDevices(PROJECT)
 
 require("lib.utils")
 
@@ -138,9 +100,9 @@ end
 print("\n[4] A device's identifier survives another device failing to resolve")
 do
   local before = indexOf("100,200,300,400")
-  hidden[200] = true
+  ShimSetDeviceHidden(200, true)
   local after = indexOf("100,200,300,400")
-  hidden[200] = nil
+  ShimSetDeviceHidden(200, false)
 
   check("200 resolved before it was hidden", before[200] == 2, describe(before))
   check("200 is gone while hidden", after[200] == nil, describe(after))

--- a/test/test_github_updater_alias.lua
+++ b/test/test_github_updater_alias.lua
@@ -1,0 +1,228 @@
+-- Tests how src/lib/utils.lua and src/lib/github-updater.lua address driver directories:
+-- the running driver's own version reads through the C4Z alias with no unlock, companion
+-- drivers unlock C4Z_ROOT first, and the download write unlocks for itself rather than
+-- inheriting an unlock from the version loop.
+--
+-- Run from the template root:
+--   LUA_PATH="$PWD/test/?.lua;$PWD/src/?.lua;$PWD/vendor/?.lua;$PWD/vendor/?/init.lua;;" \
+--     luajit -e "require('c4_shim')" test/test_github_updater_alias.lua
+
+local pass, fail = 0, 0
+local function check(name, ok, detail)
+  if ok then
+    pass = pass + 1
+    print(string.format("  ok   %s", name))
+  else
+    fail = fail + 1
+    print(string.format("  FAIL %s%s", name, detail and ("  -> " .. tostring(detail)) or ""))
+  end
+end
+
+-- tools/gen-squishy.lua bundles from package.loaded, so github-updater.lua has to require
+-- lib.utils itself rather than relying on a driver's driver.lua to have required it first.
+-- Deliberately no GetDriverVersion stub; requiring lib.github-updater must be enough.
+check(
+  "GetDriverVersion is not defined before lib.github-updater is required",
+  GetDriverVersion == nil,
+  "a stub would void this check"
+)
+
+-- The modules return already-constructed instances, not the classes.
+local updater = require("lib.github-updater")
+
+check(
+  "requiring lib.github-updater loads lib.utils",
+  package.loaded["lib.utils"] ~= nil,
+  "utils.lua is absent from package.loaded, so gen-squishy would omit it from the .c4z"
+)
+check(
+  "GetDriverVersion is callable after requiring lib.github-updater",
+  type(GetDriverVersion) == "function",
+  string.format("GetDriverVersion is %s; the version loop would fail with a nil-call", type(GetDriverVersion))
+)
+
+-- utils.lua calls Select and FileRead, which drivers-common-public defines as globals.
+require("drivers-common-public.global.lib")
+
+JSON = require("JSON")
+local deferred = require("deferred")
+local semver = require("version")
+
+local UNLOCK_KEY = "c29tZXNwZWNpYWxrZXk=++11"
+local RUNNING_DRIVER = C4:GetDriverFileName()
+local COMPANION_DRIVER = "example_companion.c4z"
+
+--- Records every C4:FileSetDir argument so each scenario can assert the order it unlocked
+--- and addressed the alias in. The shim's latch stays on once set, so ordering is what
+--- distinguishes "unlocked for itself" from "inherited an earlier unlock".
+local dirCalls = {}
+local realFileSetDir = C4.FileSetDir
+function C4:FileSetDir(dir, ...)
+  table.insert(dirCalls, dir)
+  return realFileSetDir(self, dir, ...)
+end
+
+local function resetDirCalls()
+  dirCalls = {}
+end
+
+local function indexOf(value)
+  for i, dir in ipairs(dirCalls) do
+    if dir == value then
+      return i
+    end
+  end
+  return nil
+end
+
+local function dirCallList()
+  return table.concat(dirCalls, ", ")
+end
+
+--- downloadOutdatedDrivers rejects with a table of messages indexed by number.
+local function describeError(err)
+  if type(err) ~= "table" then
+    return tostring(err)
+  end
+  local parts = {}
+  for _, message in pairs(err) do
+    table.insert(parts, tostring(message))
+  end
+  return table.concat(parts, "; ")
+end
+
+--- driver.xml is not served by the shim, so the parsed version is nil and semver would
+--- reject it. Every scenario here is about which directory was addressed.
+local realGetDriverVersion = GetDriverVersion
+local versionCalls = {}
+local versionError = nil
+function GetDriverVersion(filename)
+  table.insert(versionCalls, filename)
+  local ok, err = pcall(realGetDriverVersion, filename)
+  if not ok then
+    versionError = err
+    error(err, 0)
+  end
+  return "1.0.0"
+end
+
+local http = require("lib.http")
+
+-- Guards against passing on a no-op shim.
+check("C4Z_ROOT is locked before anything runs", not pcall(function()
+  C4:FileSetDir("C4Z_ROOT")
+end), "shim accepted C4Z_ROOT with no unlock, so this suite cannot detect the defect")
+
+---------------------------------------------------------------------------
+-- The running driver's own version read
+---------------------------------------------------------------------------
+
+resetDirCalls()
+pcall(realGetDriverVersion, RUNNING_DRIVER)
+
+check("the running driver reads through C4Z", indexOf("C4Z") ~= nil, "addressed " .. dirCallList())
+check(
+  "the running driver never unlocks C4Z_ROOT",
+  indexOf(UNLOCK_KEY) == nil and indexOf("C4Z_ROOT") == nil,
+  "addressed " .. dirCallList()
+)
+
+---------------------------------------------------------------------------
+-- The download write, on a project running a single driver from the repo
+---------------------------------------------------------------------------
+
+-- Runs before any companion read, so C4Z_ROOT is still locked and an unlock the write
+-- fails to perform surfaces as a real "Invalid alias" rather than a passing assertion.
+function updater:getLatestRelease()
+  return deferred.new():resolve({
+    version = semver("2.0.0"),
+    assets = { { name = RUNNING_DRIVER, browser_download_url = "https://example.invalid/" .. RUNNING_DRIVER } },
+  })
+end
+function http:get()
+  return deferred.new():resolve({ body = "driver payload" })
+end
+
+resetDirCalls()
+local downloaded, downloadError
+updater:downloadOutdatedDrivers("C4Z_ROOT", "finitelabs/example", { RUNNING_DRIVER }, false, false):next(function(names)
+  downloaded = names
+end, function(err)
+  downloadError = err
+end)
+
+check(
+  "the single-driver version loop leaves C4Z_ROOT locked",
+  indexOf("C4Z") ~= nil and (indexOf(UNLOCK_KEY) == nil or indexOf(UNLOCK_KEY) > indexOf("C4Z")),
+  "addressed " .. dirCallList()
+)
+check(
+  "the download write unlocks C4Z_ROOT before addressing it",
+  indexOf(UNLOCK_KEY) ~= nil and indexOf("C4Z_ROOT") ~= nil and indexOf(UNLOCK_KEY) < indexOf("C4Z_ROOT"),
+  "addressed " .. dirCallList()
+)
+check(
+  "the asset was written",
+  type(downloaded) == "table" and downloaded[1] == RUNNING_DRIVER,
+  downloadError and describeError(downloadError) or "the download chain did not resolve"
+)
+
+---------------------------------------------------------------------------
+-- A companion driver's version read
+---------------------------------------------------------------------------
+
+resetDirCalls()
+pcall(realGetDriverVersion, COMPANION_DRIVER)
+
+check(
+  "a companion driver unlocks C4Z_ROOT before addressing it",
+  indexOf(UNLOCK_KEY) ~= nil and indexOf("C4Z_ROOT") ~= nil and indexOf(UNLOCK_KEY) < indexOf("C4Z_ROOT"),
+  "addressed " .. dirCallList()
+)
+check("a companion driver does not read through C4Z", indexOf("C4Z") == nil, "addressed " .. dirCallList())
+
+---------------------------------------------------------------------------
+-- The version loop still covers every filename
+---------------------------------------------------------------------------
+
+function updater:getLatestRelease()
+  return deferred.new():resolve({ version = semver("0.0.1"), assets = {} })
+end
+
+versionCalls = {}
+versionError = nil
+local ok, err = pcall(function()
+  updater:getOutdatedDriverAssets("finitelabs/example", { RUNNING_DRIVER, COMPANION_DRIVER }, false, false)
+end)
+
+check("getOutdatedDriverAssets does not fail on the alias", ok, err)
+check("no Invalid alias error was raised", versionError == nil, versionError)
+check(
+  "every driver filename was resolved",
+  #versionCalls == 2,
+  string.format("expected 2 GetDriverVersion calls, got %d", #versionCalls)
+)
+
+---------------------------------------------------------------------------
+-- Controllers without C4:GetDriverFileName
+---------------------------------------------------------------------------
+
+local realGetDriverFileName = C4.GetDriverFileName
+C4.GetDriverFileName = nil
+
+resetDirCalls()
+pcall(realGetDriverVersion, RUNNING_DRIVER)
+
+check(
+  "without C4:GetDriverFileName the running driver falls back to C4Z_ROOT",
+  indexOf(UNLOCK_KEY) ~= nil and indexOf("C4Z_ROOT") ~= nil and indexOf(UNLOCK_KEY) < indexOf("C4Z_ROOT"),
+  "addressed " .. dirCallList()
+)
+check("the fallback does not read through C4Z", indexOf("C4Z") == nil, "addressed " .. dirCallList())
+
+C4.GetDriverFileName = realGetDriverFileName
+
+print(string.format("\n%d passed, %d failed", pass, fail))
+if fail > 0 then
+  os.exit(1)
+end

--- a/test/test_http_redact.lua
+++ b/test/test_http_redact.lua
@@ -1,7 +1,8 @@
 -- Tests for the credential redaction in src/lib/http.lua.
 --
 -- Run from the template root:
---   LUA_PATH="$PWD/src/?.lua;$PWD/vendor/?.lua;$PWD/vendor/?/init.lua;;" luajit test/test_http_redact.lua
+--   LUA_PATH="$PWD/test/?.lua;$PWD/src/?.lua;$PWD/vendor/?.lua;$PWD/vendor/?/init.lua;;" \
+--     luajit -e "require('c4_shim')" test/test_http_redact.lua
 
 local pass, fail = 0, 0
 local function check(name, ok, detail)
@@ -14,36 +15,11 @@ local function check(name, ok, detail)
   end
 end
 
--- Minimal C4 surface required to load lib.logging / lib.http.
-C4 = {}
-function C4:ErrorLog() end
-function C4:DebugLog() end
-function C4:GetDeviceID()
-  return 1
-end
-function C4:GetDeviceData()
-  return ""
-end
-function C4:AllowExecute() end
-function InRange(v)
-  return v
-end
-function IsEmpty(v)
-  return v == nil or v == ""
-end
-function urlDo() end
+-- The shim supplies the C4 surface. lib.http pulls in lib.utils (IsEmpty,
+-- InRange) and global.lib (tostring_return_period, JSON) through its own
+-- requires, so nothing is restubbed here.
+require("c4_shim")
 
--- vendor/JSON.lua calls this for every number it encodes. Without it any fixture
--- containing a number makes encode throw, and since nearly every assertion below
--- is `not contains(out, secret)`, they would all pass against the error text
--- rather than the payload. Defining it keeps those assertions meaningful.
-function tostring_return_period(value)
-  return tostring(value)
-end
-
--- Global, not local: src/lib/http.lua reads JSON as a runtime global the way the
--- driver environment provides it.
-JSON = require("JSON")
 local Http = require("lib.http")
 
 local redact = Http._redact

--- a/test/test_lib_dependencies.lua
+++ b/test/test_lib_dependencies.lua
@@ -1,0 +1,173 @@
+-- Tests that src/lib modules pull in the modules defining the globals they call,
+-- rather than relying on a driver's driver.lua to have required them first.
+--
+-- Run from the driver root:
+--   make test
+-- or:
+--   LUA_PATH="$PWD/test/?.lua;$PWD/src/?.lua;$PWD/src/?/init.lua;$PWD/vendor/?.lua;$PWD/vendor/?/init.lua;;" \
+--     luajit -e "require('c4_shim')" test/test_lib_dependencies.lua
+--
+-- tools/gen-squishy.lua bundles from package.loaded, so a module nothing
+-- requires is absent from the .c4z and fails as a nil-call in the field.
+--
+-- The required set is derived from the sources rather than listed here, because a
+-- listed one would go stale the first time a module gained a call. A module can
+-- also reach a global transitively through a sibling it requires, so the runtime
+-- check alone passes on a missing declaration; the source check is what holds each
+-- module to declaring what it uses itself.
+
+local pass, fail = 0, 0
+local function check(name, ok, detail)
+  if ok then
+    pass = pass + 1
+    print(string.format("  ok   %s", name))
+  else
+    fail = fail + 1
+    print(string.format("  FAIL %s%s", name, detail and ("  -> " .. tostring(detail)) or ""))
+  end
+end
+
+local function dirOf(module)
+  local path = package.searchpath(module, package.path)
+  return path and path:match("^(.*)[/\\][^/\\]+$")
+end
+
+local function readFile(path)
+  local fh = io.open(path, "r")
+  if not fh then
+    return nil
+  end
+  local body = fh:read("*a")
+  fh:close()
+  return body
+end
+
+local function ls(dir)
+  local names = {}
+  local pipe = io.popen(string.format("ls %q 2>/dev/null", dir))
+  if not pipe then
+    return names
+  end
+  for name in pipe:lines() do
+    table.insert(names, name)
+  end
+  pipe:close()
+  return names
+end
+
+--- Lua has no comment-aware lexer here; dropping to end of line over a source with
+--- no inline `--` inside strings is enough to keep doc comments from reading as calls.
+local function stripComments(src)
+  local out = {}
+  for line in (src .. "\n"):gmatch("([^\n]*)\n") do
+    table.insert(out, (line:gsub("%-%-.*$", "")))
+  end
+  return table.concat(out, "\n")
+end
+
+local function definedIn(src)
+  local names = {}
+  for name in src:gmatch("function%s+([%a_][%w_]*)%s*%(") do
+    names[name] = true
+  end
+  return names
+end
+
+local libDir = dirOf("lib.logging")
+local dcpDir = dirOf("drivers-common-public.global.lib")
+
+check("src/lib is on package.path", libDir ~= nil, "cannot locate lib.logging")
+check("drivers-common-public is on package.path", dcpDir ~= nil, "cannot locate the global modules")
+
+if libDir and dcpDir then
+  -- global name -> the drivers-common-public module that defines it
+  local owner = {}
+  for _, name in ipairs(ls(dcpDir)) do
+    local mod = name:match("^(.+)%.lua$")
+    local body = mod and readFile(dcpDir .. "/" .. name)
+    if body then
+      -- Leading %s* so indented defs (e.g. globals inside a `do` block) are seen,
+      -- not just column-0 ones. `local function` stays excluded: `local` breaks it.
+      for fn in stripComments(body):gmatch("\n%s*function%s+([%a_][%w_]*)%s*%(") do
+        owner[fn] = "drivers-common-public.global." .. mod
+      end
+    end
+  end
+  check("the global modules define globals to check for", next(owner) ~= nil)
+
+  -- src/lib modules define globals too (utils.lua's IsEmpty, InRange, ...) that
+  -- siblings call. Map those the same way, so an intra-lib missing require is
+  -- caught as well -- the DRV-97 class one level in. A module defining a global
+  -- is excluded from needing it below via `own`, so self-references don't flag.
+  for _, name in ipairs(ls(libDir)) do
+    local mod = name:match("^(.+)%.lua$")
+    local body = mod and readFile(libDir .. "/" .. name)
+    if body then
+      for fn in stripComments(body):gmatch("\n%s*function%s+([%a_][%w_]*)%s*%(") do
+        owner[fn] = "lib." .. mod
+      end
+    end
+  end
+
+  for _, name in ipairs(ls(libDir)) do
+    local mod = name:match("^(.+)%.lua$")
+    local raw = mod and readFile(libDir .. "/" .. name)
+    if raw then
+      local src = stripComments(raw)
+      local own = definedIn(src)
+
+      -- drivers-common-public modules this file needs, by the globals it calls
+      local needed, order = {}, {}
+      for fn in src:gmatch("[^%w_.:]([%a_][%w_]*)%s*%(") do
+        if owner[fn] and not own[fn] and not needed[owner[fn]] then
+          needed[owner[fn]] = fn
+          table.insert(order, owner[fn])
+        end
+      end
+      table.sort(order)
+
+      for _, dep in ipairs(order) do
+        check(
+          string.format("src/lib/%s declares require(%q)", name, dep),
+          raw:find(string.format('require("%s")', dep), 1, true) ~= nil,
+          string.format("calls %s but never requires the module defining it", needed[dep])
+        )
+      end
+
+      if #order > 0 then
+        -- Stand in for a driver.lua that required nothing: drop every module this
+        -- one could reach so the require under test has to supply the globals.
+        for loaded in pairs(package.loaded) do
+          if loaded:match("^lib%.") or loaded:match("^drivers%-common%-public%.") then
+            package.loaded[loaded] = nil
+          end
+        end
+        for fn in pairs(needed) do
+          _G[fn] = nil
+        end
+        for _, dep in ipairs(order) do
+          _G[needed[dep]] = nil
+        end
+
+        local ok, err = pcall(require, "lib." .. mod)
+        check(string.format("src/lib/%s requires cleanly with no driver.lua setup", name), ok, err)
+
+        if ok then
+          for _, dep in ipairs(order) do
+            local fn = needed[dep]
+            check(
+              string.format("src/lib/%s: %s is callable after the require", name, fn),
+              type(_G[fn]) == "function",
+              string.format("%s is %s; the call site would fail with a nil-call", fn, type(_G[fn]))
+            )
+          end
+        end
+      end
+    end
+  end
+end
+
+print(string.format("\n%d passed, %d failed", pass, fail))
+if fail > 0 then
+  os.exit(1)
+end

--- a/test/test_watched_variable.lua
+++ b/test/test_watched_variable.lua
@@ -1,0 +1,148 @@
+-- Tests for handler dispatch when Director will not name the firing device.
+--
+-- C4:GetDeviceDisplayName returns *no value* (arity 0, not nil) for an id that
+-- is not a project item. Director's synthetic delay (100000) and variables
+-- (100001) agents are exactly that, and 100001 is where every Composer global
+-- lives. OnWatchedVariableChanged used to concatenate that result directly, so
+-- the throw landed on the line building the debug string -- above the dispatch
+-- to the driver's callback and above the xpcall that would have reported it.
+-- The driver saw silence, not an error: watched globals never updated, and a
+-- restart appeared to fix it until the next change. OnDeviceEvent had the same
+-- unguarded call.
+--
+-- HandlerDebug returns early unless DEBUGPRINT, but `init` is built before the
+-- call, so debug being off did not spare production. Both states are covered.
+--
+-- Regression test for DRV-95.
+--
+-- Run from the driver root:
+--   make test
+-- or:
+--   LUA_PATH="$PWD/test/?.lua;$PWD/src/?.lua;$PWD/src/?/init.lua;$PWD/vendor/?.lua;$PWD/vendor/?/init.lua;;" \
+--     luajit -e "require('c4_shim')" test/test_watched_variable.lua
+
+require("drivers-common-public.global.lib") -- Select, GetDeviceDisplayNameOrId
+require("drivers-common-public.global.handlers") -- OWVC, ODE, OnWatchedVariableChanged, OnDeviceEvent
+
+local pass, fail = 0, 0
+local function check(name, ok, detail)
+  if ok then
+    pass = pass + 1
+    print(string.format("  ok   %s", name))
+  else
+    fail = fail + 1
+    print(string.format("  FAIL %s%s", name, detail and ("  -> " .. tostring(detail)) or ""))
+  end
+end
+
+-- The shim owns C4:GetDevices / GetDeviceDisplayName / GetDeviceVariables. A
+-- device with no deviceName is the nameless case the fix turns on: the shim
+-- returns no value at all (arity 0), as the controller does, so code that
+-- concatenates the result directly still throws. 100001 is Director's variables
+-- agent -- variables, no name -- and 100000 is the delay agent.
+require("c4_shim")
+ShimSetDevices({
+  [2787] = { deviceName = "InfluxDB Data Logger" },
+  [2341] = { deviceName = "Master Bathroom Humidity", variables = { ["1012"] = { name = "HUMIDITY" } } },
+  [100001] = { variables = { ["2301"] = { name = "MB_HIGH_HUMIDITY_DIFF_THRESHOLD" } } },
+})
+
+--- Capture whatever HandlerDebug prints so the debug line itself can be asserted.
+local captured
+local realPrint = print
+local function withCapturedPrint(fn)
+  captured = {}
+  print = function(...) -- luacheck: ignore
+    local parts = {}
+    for i = 1, select("#", ...) do
+      parts[i] = tostring((select(i, ...)))
+    end
+    table.insert(captured, table.concat(parts, " "))
+  end
+  local ok, err = pcall(fn)
+  print = realPrint -- luacheck: ignore
+  return ok, err
+end
+
+local function debugOutput()
+  return table.concat(captured, "\n")
+end
+
+-- ── The regression: a variable on the nameless agent ──────────────────────────
+
+DEBUGPRINT = false
+
+local fired = {}
+RegisterVariableListener(100001, 2301, function(idDevice, idVariable, strValue)
+  table.insert(fired, { idDevice, idVariable, strValue })
+end)
+
+local ok, err = withCapturedPrint(function()
+  OnWatchedVariableChanged(100001, 2301, "2")
+end)
+check("the callback runs for a device Director will not name", ok and #fired == 1, err or ("fired=" .. #fired))
+check("it receives the new value", fired[1] and fired[1][3] == "2", fired[1] and fired[1][3])
+
+-- ── The same variable with debug on: the line is built, and it is readable ────
+
+DEBUGPRINT = true
+fired = {}
+ok, err = withCapturedPrint(function()
+  OnWatchedVariableChanged(100001, 2301, "3")
+end)
+check("debug on does not throw either", ok and #fired == 1, err or ("fired=" .. #fired))
+check(
+  "the nameless device falls back to its id",
+  debugOutput():find("OnWatchedVariableChanged: device 100001 [100001]", 1, true) ~= nil,
+  debugOutput()
+)
+check(
+  "the variable name still resolves",
+  debugOutput():find("MB_HIGH_HUMIDITY_DIFF_THRESHOLD [2301]", 1, true) ~= nil,
+  debugOutput()
+)
+
+-- ── A named device is unaffected ──────────────────────────────────────────────
+
+fired = {}
+RegisterVariableListener(2341, 1012, function(idDevice, idVariable, strValue)
+  table.insert(fired, { idDevice, idVariable, strValue })
+end)
+ok, err = withCapturedPrint(function()
+  OnWatchedVariableChanged(2341, 1012, "54")
+end)
+check("a named device still dispatches", ok and #fired == 1, err or ("fired=" .. #fired))
+check(
+  "and still prints its display name, not its id",
+  debugOutput():find("OnWatchedVariableChanged: Master Bathroom Humidity [2341]", 1, true) ~= nil,
+  debugOutput()
+)
+
+-- ── OnDeviceEvent carried the identical bug ───────────────────────────────────
+
+local eventsSeen = {}
+RegisterDeviceEvent(100001, 1, function(firingDeviceId, eventId)
+  table.insert(eventsSeen, { firingDeviceId, eventId })
+end)
+
+ok, err = withCapturedPrint(function()
+  OnDeviceEvent(100001, 1)
+end)
+check("OnDeviceEvent dispatches for a nameless device", ok and #eventsSeen == 1, err or ("seen=" .. #eventsSeen))
+check(
+  "and falls back to the id in its debug line",
+  debugOutput():find("OnDeviceEvent: device 100001 [100001]", 1, true) ~= nil,
+  debugOutput()
+)
+
+-- ── The helper itself ─────────────────────────────────────────────────────────
+
+check("GetDeviceDisplayNameOrId prefers the real name", GetDeviceDisplayNameOrId(2787) == "InfluxDB Data Logger")
+check("GetDeviceDisplayNameOrId falls back for 100001", GetDeviceDisplayNameOrId(100001) == "device 100001")
+check("GetDeviceDisplayNameOrId falls back for 100000", GetDeviceDisplayNameOrId(100000) == "device 100000")
+check("GetDeviceDisplayNameOrId tolerates a nil id", GetDeviceDisplayNameOrId(nil) == "device nil")
+
+DEBUGPRINT = false
+
+print(string.format("\n%d passed, %d failed", pass, fail))
+os.exit(fail == 0 and 0 or 1)

--- a/test/test_websocket.lua
+++ b/test/test_websocket.lua
@@ -5,7 +5,7 @@
 --   4. 64-bit extended-length field uses %016X
 --
 -- Run from the template root:
---   LUA_PATH="$PWD/vendor/?.lua;$PWD/vendor/?/init.lua;;" luajit test/test_websocket.lua
+--   LUA_PATH="$PWD/test/?.lua;$PWD/vendor/?.lua;$PWD/vendor/?/init.lua;;" luajit test/test_websocket.lua
 
 local pass, fail = 0, 0
 local function check(name, ok, detail)
@@ -19,82 +19,23 @@ local function check(name, ok, detail)
 end
 
 --------------------------------------------------------------------------------
--- C4 shim
+-- C4 surface
+--
+-- Every call this file needs is DriverWorks, so it comes from the shim instead
+-- of being redeclared here. Redeclaring is how the two copies of C4:KillTimer
+-- drifted: one gained an error level and the other kept the old one.
 --------------------------------------------------------------------------------
-local bindingAddress = {} -- [binding] = host   (never cleared: mirrors the real leak)
-local bindingPort = {}
-local sentFrames = {}
+require("c4_shim")
 
--- Real C4 timers, so tests can drive the actual Close()/delete() path rather
--- than reimplementing its bookkeeping. drivers-common-public.global.timer wraps
--- these, so the module's own SetTimer/CancelTimer work unmodified.
-local pendingTimers = {}
-local nextTimerHandle = 0
+local bindingAddress, bindingPort = ShimNetworkBindings()
+local sentFrames = ShimSentFrames()
 
-C4 = {}
-function C4:GetBindingAddress(i)
-  return bindingAddress[i] or ""
-end
-function C4:CreateNetworkConnection(binding, host, _type)
-  bindingAddress[binding] = host
-end
-function C4:NetPortOptions(binding, port, _t, _o)
-  bindingPort[binding] = port
-end
-function C4:NetConnect() end
-function C4:NetDisconnect() end
-function C4:SendToNetwork(binding, port, data)
-  sentFrames[#sentFrames + 1] = { binding = binding, port = port, data = data }
-end
--- Deliberately a no-op: this is the real behaviour the binding cache exists for.
--- C4 re-resolves the host and re-populates the address, so the slot is not freed.
-function C4:SetBindingAddress() end
-function C4:Base64Encode(s)
-  return "b64:" .. tostring(s):sub(1, 8)
-end
-function C4:ErrorLog() end
+-- websocket.lua logs on every frame, which would bury the results.
 function C4:DebugLog() end
-function C4:GetDeviceID()
-  return 1
-end
--- A real C4 timer handle is userdata carrying a :Cancel() method, and
--- global/timer.lua calls timer:Cancel() on it, so the shim returns a table with
--- the same shape rather than a bare id.
-function C4:SetTimer(_delay, fn, _repeating)
-  nextTimerHandle = nextTimerHandle + 1
-  local id = nextTimerHandle
-  local handle
-  handle = {
-    Cancel = function()
-      pendingTimers[id] = nil
-      return nil
-    end,
-  }
-  pendingTimers[id] = { fn = fn, handle = handle }
-  return handle
-end
-function C4:KillTimer(handle)
-  for id, entry in pairs(pendingTimers) do
-    if entry.handle == handle then
-      pendingTimers[id] = nil
-    end
-  end
-  return 0
-end
 
 --- Fire every pending timer, which is what makes the 3-second close timer run.
-local function fireTimers()
-  local snapshot = {}
-  for id, entry in pairs(pendingTimers) do
-    snapshot[id] = entry
-  end
-  for id, entry in pairs(snapshot) do
-    if pendingTimers[id] then
-      pendingTimers[id] = nil
-      entry.fn(entry.handle, 0)
-    end
-  end
-end
+--- ShimFireTimers ignores the clock, so this works with or without luasocket.
+local fireTimers = ShimFireTimers
 
 -- C4 global: hex string -> packed bytes
 function tohex(s)
@@ -128,7 +69,7 @@ local function bindingsInUse()
 end
 
 local function resetBindings()
-  bindingAddress, bindingPort = {}, {}
+  ShimResetBindings()
 end
 
 --------------------------------------------------------------------------------
@@ -137,17 +78,17 @@ print("\n[1] Send() default opcode unchanged (0x81 text frame)")
 do
   local ws = WebSocket:new("wss://text.example.com/ws")
   ws.connected = true
-  sentFrames = {}
+  ShimResetSentFrames()
   ws:Send("hello")
   local first = sentFrames[1] and sentFrames[1].data:byte(1)
   check("legacy Send(s) still emits 0x81", first == 0x81, string.format("got 0x%02X", first or 0))
 
-  sentFrames = {}
+  ShimResetSentFrames()
   ws:Send("hello", 0x82)
   first = sentFrames[1] and sentFrames[1].data:byte(1)
   check("Send(s, 0x82) emits binary frame", first == 0x82, string.format("got 0x%02X", first or 0))
 
-  sentFrames = {}
+  ShimResetSentFrames()
   ws:Send(string.rep("x", 300)) -- 126 extended-length branch
   first = sentFrames[1] and sentFrames[1].data:byte(1)
   check("126-branch keeps 0x81 default", first == 0x81, string.format("got 0x%02X", first or 0))
@@ -162,7 +103,7 @@ do
   ws.connected = true
 
   local payload = string.rep("y", 70000) -- > 65535, so the 127 branch
-  sentFrames = {}
+  ShimResetSentFrames()
   ws:Send(payload)
   local data = sentFrames[1] and sentFrames[1].data or ""
 

--- a/tools/gen-squishy.lua
+++ b/tools/gen-squishy.lua
@@ -113,7 +113,7 @@ for _, mod in ipairs(modules) do
 end
 
 table.insert(lines, "")
-table.insert(lines, string.format('Output "../../../../dist/%s/%s.lua"', condition, driver_name))
+table.insert(lines, string.format('Output "../../../../dist/%s/source/%s.lua"', condition, driver_name))
 table.insert(lines, 'Option "minify" "true"')
 table.insert(lines, 'Option "minify_level" "none"')
 table.insert(lines, 'Option "minify_comments" "true"')

--- a/tools/package.py
+++ b/tools/package.py
@@ -9,8 +9,9 @@ Subcommands:
       Set /devicedata/<version|modified> text in place, preserving the rest of
       the file byte-for-byte. (replaces: xmlstarlet edit --inplace)
 
-  package.py zip <output.zip> <file>...
-      Create a zip of the given files (stored flat, basenames).
+  package.py zip <output.zip> <path>...
+      Create a zip of the given paths. Files are stored flat by basename;
+      directories are added recursively, preserving their relative paths.
       (replaces: the `zip` CLI)
 """
 
@@ -43,10 +44,18 @@ def xml_set(xml_path: Path, tag: str, value: str) -> None:
     xml_path.write_text(new_text, encoding="utf-8")
 
 
-def make_zip(output_path: Path, files: list[Path]) -> None:
+def make_zip(output_path: Path, inputs: list[str]) -> None:
     with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        for f in files:
-            zf.write(f, arcname=f.name)
+        for item in inputs:
+            p = Path(item)
+            if p.is_dir():
+                for f in sorted(p.rglob("*")):
+                    if f.is_file():
+                        zf.write(f, arcname=f.as_posix())
+            elif p.is_file():
+                zf.write(p, arcname=p.name)
+            else:
+                raise FileNotFoundError(f"zip: no such file or directory: {item}")
 
 
 def main() -> int:
@@ -57,7 +66,7 @@ def main() -> int:
     elif cmd == "xml-set" and len(rest) == 3:
         xml_set(Path(rest[0]).resolve(), rest[1], rest[2])
     elif cmd == "zip" and len(rest) >= 2:
-        make_zip(Path(rest[0]).resolve(), [Path(p).resolve() for p in rest[1:]])
+        make_zip(Path(rest[0]).resolve(), rest[1:])
     else:
         print(__doc__, file=sys.stderr)
         return 1

--- a/vendor/bitn.lua
+++ b/vendor/bitn.lua
@@ -3297,7 +3297,7 @@ local bitn = {
 }
 
 --- Library version (injected at build time for releases).
-local VERSION = "v0.6.1"
+local VERSION = "v0.6.2"
 
 --- Get the library version string.
 --- @return string version Version string (e.g., "v1.0.0" or "dev")

--- a/vendor/bthome.lua
+++ b/vendor/bthome.lua
@@ -3423,7 +3423,7 @@ bthome.UUID_V1_ENCRYPTED = bthome.parser.UUID_V1_ENCRYPTED
 bthome.UUID_V2 = bthome.parser.UUID_V2
 
 --- Library version (injected at build time for releases).
-local VERSION = "v0.1.3"
+local VERSION = "v0.1.4"
 
 --- Get the library version string.
 --- @return string version Version string (e.g., "v1.0.0" or "dev")

--- a/vendor/crypto.lua
+++ b/vendor/crypto.lua
@@ -12520,7 +12520,7 @@ local crypto = {
 local openssl_wrapper = crypto.openssl_wrapper
 
 --- Library version (injected at build time for releases).
-local VERSION = "v0.2.0"
+local VERSION = "v0.2.1"
 
 --- Enable or disable OpenSSL acceleration for the primitives that support it
 --- (hashing and AEAD). Opt-in and safe: when the lua-openssl binding is

--- a/vendor/drivers-common-public/global/handlers.lua
+++ b/vendor/drivers-common-public/global/handlers.lua
@@ -456,7 +456,7 @@ function OnDeviceEvent(firingDeviceId, eventId)
 
   if not suppressDebug then
     local init = {
-      "OnDeviceEvent: " .. C4:GetDeviceDisplayName(firingDeviceId) .. " [" .. firingDeviceId .. "]",
+      "OnDeviceEvent: " .. GetDeviceDisplayNameOrId(firingDeviceId) .. " [" .. firingDeviceId .. "]",
       eventId,
     }
     HandlerDebug(init)
@@ -757,7 +757,7 @@ function OnWatchedVariableChanged(idDevice, idVariable, strValue)
 
   if not suppressDebug then
     local init = {
-      "OnWatchedVariableChanged: " .. C4:GetDeviceDisplayName(idDevice) .. " [" .. idDevice .. "]",
+      "OnWatchedVariableChanged: " .. GetDeviceDisplayNameOrId(idDevice) .. " [" .. idDevice .. "]",
     }
     local varName = Select(C4:GetDeviceVariables(idDevice), tostring(idVariable), "name") or ""
     varName = varName .. " [" .. idVariable .. "]"

--- a/vendor/drivers-common-public/global/lib.lua
+++ b/vendor/drivers-common-public/global/lib.lua
@@ -1385,6 +1385,13 @@ function GetTruthy(value, emptyValueIsTrue)
   return ret
 end
 
+-- C4:GetDeviceDisplayName returns no value for an id Director does not list as a
+-- project item, such as the synthetic delay (100000) and variables (100001)
+-- agents, so concatenating its result directly throws.
+function GetDeviceDisplayNameOrId(deviceId)
+  return C4:GetDeviceDisplayName(deviceId) or ("device " .. tostring(deviceId))
+end
+
 function RenameDevice(deviceId, newName)
   deviceId = tonumber(deviceId)
   if type(deviceId) ~= "number" then

--- a/vendor/noiseprotocol.lua
+++ b/vendor/noiseprotocol.lua
@@ -772,7 +772,7 @@ local utils = require("noiseprotocol.utils")
 local openssl_wrapper = require("crypto.openssl_wrapper")
 
 --- Module version
-local VERSION = "v0.6.2"
+local VERSION = "v0.6.3"
 
 --- Enable or disable OpenSSL acceleration
 --- @function use_openssl

--- a/vendor/protobuf.lua
+++ b/vendor/protobuf.lua
@@ -62,7 +62,7 @@ local function is_list(t)
 end
 
 -- Version
-local VERSION = "v0.6.5"
+local VERSION = "v0.6.6"
 
 --- Returns the library version.
 --- @return string version The version string.


### PR DESCRIPTION
## Summary

Rolls this repo onto copier template **v0.9.15** (from v0.9.14) as part of the DRV-99 Phase 2 fleet update.

Template v0.9.15 brings: require-hygiene lib fixes, a completed test shim plus new suites, stylua-formatted vendored amalgams gated by `make check`, the new `dist/` layout (`c4z`/`docs`/`source`), and re-vendored core amalgams.

### vendor_modules dedupe

This repo's stored answer was buggy. It carried a duplicate `protobuf` and the now-mandatory `json deferred drivers-common-public xml` prefix that must no longer be listed:

- **before:** `json deferred drivers-common-public xml bitn crypto bthome noiseprotocol protobuf protobuf`
- **after:** `bitn crypto bthome noiseprotocol protobuf`

The four mandatory modules were dropped from the answer (they are now unconditional) and the double `protobuf` collapsed to one. All five crypto amalgams (`bitn`, `crypto`, `bthome`, `noiseprotocol`, `protobuf`) survive on disk, and the mandatory `JSON.lua`, `deferred.lua`, `drivers-common-public/`, and `xml/` remain present.

### Post-update cleanups

- Removed the dead `C4Z_ROOT` `FileSetDir` unlock in `drivers/esphome/driver.lua` (dead post-#31, DRV-79) — 1 site.
- Removed the redundant `require("drivers-common-public.global.url")` from all four `driver.lua` files (`esphome`, `esphome_switchbot`, `esphome_yale`, `esphome_bluetooth_coordinator`) — `lib.http` pulls `url` in itself.

### Validation

- `make init`, `make check`, `make test` (35 assertions across suites), `make build` all exit 0.
- Idempotent: a second `make build` produces no non-`dist/`/`build/` changes.
- url sanity: `esphome`, `esphome_switchbot`, `esphome_yale` still show `urlDo` in built source; `esphome_bluetooth_coordinator` legitimately shows 0 (it never used `lib.http`).