### PR TITLE
docs(changelog): capture pending unreleased changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ## Unreleased
 
+### Added
+
+- Added the konnected Smart Garage Door Opener to the verified devices, and
+  generalized the ratgdo setup into a shared Garage Door Configuration guide
+  that covers both.
+
 ### Fixed
 
 - Fixed Bluetooth proxies logging a spurious "Property 'Select Bluetooth

--- a/README.md
+++ b/README.md
@@ -906,6 +906,12 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ## Unreleased
 
+### Added
+
+- Added the konnected Smart Garage Door Opener to the verified devices, and
+  generalized the ratgdo setup into a shared Garage Door Configuration guide
+  that covers both.
+
 ### Fixed
 
 - Fixed Bluetooth proxies logging a spurious "Property 'Select Bluetooth


### PR DESCRIPTION
Adds the end-user changelog entry for a change since the last release that wasn't yet in `Unreleased`: note the konnected Smart Garage Door Opener as a verified device. CHANGELOG.md only, integrator-facing voice, mdformat-clean.