### PR TITLE
fix: thermostat scale, thermostat online status, and light dimming caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
   ESPHome device went offline.
 - Fixed an "Error setting default color rate from driver" message in Composer
   when opening the properties of an ESPHome light.
+- Fixed Composer's test panel greying out the dimming controls for ESPHome
+  lights that do support brightness. The Control4 app was always able to dim
+  these lights; only Composer's own test controls were affected.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 - Fixed an "Error setting default color rate from driver" message in Composer
   when opening the properties of an ESPHome light.
 - Fixed Composer's test panel greying out the dimming controls for ESPHome
-  lights that do support brightness. The Control4 app was always able to dim
-  these lights; only Composer's own test controls were affected.
+  lights that do support brightness. Dimming from the Control4 app was never
+  affected.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 - Fixed an automatic update sometimes leaving companion drivers on the previous
   version until the next update, which could make them stop responding in the
   meantime.
+- Fixed thermostats and water heaters always showing Fahrenheit. They now follow
+  the project's temperature scale, and the Celsius/Fahrenheit setting in
+  Composer can be used to override it for an individual thermostat.
+- Fixed thermostats and water heaters staying shown as connected after the
+  ESPHome device went offline.
+- Fixed the dimming controls being greyed out in Composer for ESPHome lights
+  that do support brightness.
+- Fixed an "Error setting default color rate from driver" message in Composer
+  when opening the properties of an ESPHome light.
+
+### Changed
+
+- Documented the `Connected` variable that every driver publishes, so it can be
+  used in Programming to show whether a device is online.
 
 <!-- #endif -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,6 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
   Composer can be used to override it for an individual thermostat.
 - Fixed thermostats and water heaters staying shown as connected after the
   ESPHome device went offline.
-- Fixed the dimming controls being greyed out in Composer for ESPHome lights
-  that do support brightness.
 - Fixed an "Error setting default color rate from driver" message in Composer
   when opening the properties of an ESPHome light.
 

--- a/README.md
+++ b/README.md
@@ -923,8 +923,6 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
   Composer can be used to override it for an individual thermostat.
 - Fixed thermostats and water heaters staying shown as connected after the
   ESPHome device went offline.
-- Fixed the dimming controls being greyed out in Composer for ESPHome lights
-  that do support brightness.
 - Fixed an "Error setting default color rate from driver" message in Composer
   when opening the properties of an ESPHome light.
 

--- a/README.md
+++ b/README.md
@@ -435,15 +435,22 @@ supported ESPHome entity. Use this reference for Control4 programming.
 ### Driver Variables
 
 In addition to per-entity variables, the driver publishes the following
-device-level variables sourced from the ESPHome device info. They mirror the
-matching read-only Device Info properties.
+device-level variables. `Connected` tracks the live connection; the rest mirror
+the matching read-only Device Info properties.
 
-| Variable     | Type   | Description                                  |
-| ------------ | ------ | -------------------------------------------- |
-| Name         | STRING | Friendly name reported by the ESPHome device |
-| Model        | STRING | Device model string reported by ESPHome      |
-| Manufacturer | STRING | Manufacturer string reported by ESPHome      |
-| MAC Address  | STRING | ESPHome device MAC address                   |
+| Variable     | Type   | Description                                    |
+| ------------ | ------ | ---------------------------------------------- |
+| Connected    | BOOL   | True while the driver is talking to the device |
+| Name         | STRING | Friendly name reported by the ESPHome device   |
+| Model        | STRING | Device model string reported by ESPHome        |
+| Manufacturer | STRING | Manufacturer string reported by ESPHome        |
+| MAC Address  | STRING | ESPHome device MAC address                     |
+
+> **Tip:** Every sub-driver publishes its own `Connected` variable too, tracking
+> the entity it is bound to. Use it in Programming to drive a custom Navigator
+> element, send a notification, or trigger anything else when a device drops
+> off. Thermostats, lights and fans additionally report their connection state
+> to their proxy, so Navigator greys them out on its own.
 
 ### Variables by Entity Type
 
@@ -911,6 +918,20 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 - Fixed an automatic update sometimes leaving companion drivers on the previous
   version until the next update, which could make them stop responding in the
   meantime.
+- Fixed thermostats and water heaters always showing Fahrenheit. They now follow
+  the project's temperature scale, and the Celsius/Fahrenheit setting in
+  Composer can be used to override it for an individual thermostat.
+- Fixed thermostats and water heaters staying shown as connected after the
+  ESPHome device went offline.
+- Fixed the dimming controls being greyed out in Composer for ESPHome lights
+  that do support brightness.
+- Fixed an "Error setting default color rate from driver" message in Composer
+  when opening the properties of an ESPHome light.
+
+### Changed
+
+- Documented the `Connected` variable that every driver publishes, so it can be
+  used in Programming to show whether a device is online.
 
 ## v20260816 - 2026-08-16
 

--- a/README.md
+++ b/README.md
@@ -925,6 +925,9 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
   ESPHome device went offline.
 - Fixed an "Error setting default color rate from driver" message in Composer
   when opening the properties of an ESPHome light.
+- Fixed Composer's test panel greying out the dimming controls for ESPHome
+  lights that do support brightness. The Control4 app was always able to dim
+  these lights; only Composer's own test controls were affected.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -926,8 +926,8 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 - Fixed an "Error setting default color rate from driver" message in Composer
   when opening the properties of an ESPHome light.
 - Fixed Composer's test panel greying out the dimming controls for ESPHome
-  lights that do support brightness. The Control4 app was always able to dim
-  these lights; only Composer's own test controls were affected.
+  lights that do support brightness. Dimming from the Control4 app was never
+  affected.
 
 ### Changed
 

--- a/drivers/esphome/www/documentation/index.md
+++ b/drivers/esphome/www/documentation/index.md
@@ -535,15 +535,22 @@ supported ESPHome entity. Use this reference for Control4 programming.
 ### Driver Variables
 
 In addition to per-entity variables, the driver publishes the following
-device-level variables sourced from the ESPHome device info. They mirror the
-matching read-only Device Info properties.
+device-level variables. `Connected` tracks the live connection; the rest mirror
+the matching read-only Device Info properties.
 
-| Variable     | Type   | Description                                  |
-| ------------ | ------ | -------------------------------------------- |
-| Name         | STRING | Friendly name reported by the ESPHome device |
-| Model        | STRING | Device model string reported by ESPHome      |
-| Manufacturer | STRING | Manufacturer string reported by ESPHome      |
-| MAC Address  | STRING | ESPHome device MAC address                   |
+| Variable     | Type   | Description                                    |
+| ------------ | ------ | ---------------------------------------------- |
+| Connected    | BOOL   | True while the driver is talking to the device |
+| Name         | STRING | Friendly name reported by the ESPHome device   |
+| Model        | STRING | Device model string reported by ESPHome        |
+| Manufacturer | STRING | Manufacturer string reported by ESPHome        |
+| MAC Address  | STRING | ESPHome device MAC address                     |
+
+> **Tip:** Every sub-driver publishes its own `Connected` variable too, tracking
+> the entity it is bound to. Use it in Programming to drive a custom Navigator
+> element, send a notification, or trigger anything else when a device drops
+> off. Thermostats, lights and fans additionally report their connection state
+> to their proxy, so Navigator greys them out on its own.
 
 ### Variables by Entity Type
 

--- a/drivers/esphome_bluetooth_coordinator/www/documentation/index.md
+++ b/drivers/esphome_bluetooth_coordinator/www/documentation/index.md
@@ -529,6 +529,12 @@ ID for rooms) to avoid conflicts.
 Variable names for per-device and per-room variables include a unique suffix
 (MAC address for devices, room ID for rooms) to avoid conflicts.
 
+### Driver Variables
+
+| Variable  | Type | Description                                                     |
+| --------- | ---- | --------------------------------------------------------------- |
+| Connected | BOOL | True while the coordinator is running (Driver Status "Running") |
+
 ### Per-Device Variables
 
 | Variable                         | Type   | Description                                                          |

--- a/drivers/esphome_bthome/www/documentation/index.md
+++ b/drivers/esphome_bthome/www/documentation/index.md
@@ -403,13 +403,14 @@ match the property names shown in Composer Pro.
 
 ### Common Variables
 
-| Variable         | Type   | Description                 |
-| ---------------- | ------ | --------------------------- |
-| Name             | STRING | Device name                 |
-| Device Type      | STRING | Detected BTHome device type |
-| Device Type ID   | NUMBER | BTHome device type ID       |
-| Firmware Version | STRING | Device firmware version     |
-| MAC Address      | STRING | Device MAC address          |
+| Variable         | Type   | Description                        |
+| ---------------- | ------ | ---------------------------------- |
+| Connected        | BOOL   | True while the device is reporting |
+| Name             | STRING | Device name                        |
+| Device Type      | STRING | Detected BTHome device type        |
+| Device Type ID   | NUMBER | BTHome device type ID              |
+| Firmware Version | STRING | Device firmware version            |
+| MAC Address      | STRING | Device MAC address                 |
 
 > **Note:** `Last Seen` and `RSSI` are read-only driver properties (see
 > [Device Info](#device-info)) and do not appear as programming variables.

--- a/drivers/esphome_climate/driver.lua
+++ b/drivers/esphome_climate/driver.lua
@@ -126,6 +126,50 @@ local C4_TO_CLIMATE_FAN_MODE = TableReverse(CLIMATE_FAN_MODE_TO_C4)
 --- and the proxy converts to the user's display scale based on the SCALE param.
 local SCALE = "C"
 
+--- Persist key for an installer's per-thermostat display-scale override.
+local P_DISPLAY_SCALE = "DisplayScale"
+
+--- Normalize any of the scale spellings the proxy uses ("C"/"F",
+--- "Celsius"/"Fahrenheit", "CELSIUS"/"FAHRENHEIT") to a single letter.
+--- @param scale string|nil
+--- @return string|nil scale "C", "F", or nil if unrecognized.
+local function normalizeScale(scale)
+  local first = tostring(scale or ""):sub(1, 1):upper()
+  if first == "C" or first == "F" then
+    return first
+  end
+  return nil
+end
+
+--- The scale the thermostat should display in. An installer override set from
+--- Composer or programming (SET_SCALE) wins; otherwise follow the project's
+--- temperature scale. ESPHome itself is always Celsius, so this is purely a
+--- display concern and nothing is pushed to the device.
+--- @return string scale "C" or "F".
+local function getDisplayScale()
+  return normalizeScale(persist:get(P_DISPLAY_SCALE)) or normalizeScale(C4:GetTemperatureScale()) or "F"
+end
+
+--- Report the ESPHome device's reachability to the thermostat proxy.
+--- thermostatV2 has no ONLINE_CHANGED; it tracks reachability through
+--- CONNECTION/CONNECTED, which drives the proxy's IS_CONNECTED variable and the
+--- offline indicator Navigator shows on the thermostat.
+--- @param connected boolean
+--- @return void
+local function sendConnectionState(connected)
+  SendToProxy(PROXY_BINDING, "CONNECTION", { CONNECTED = connected and "true" or "false" }, "NOTIFY")
+end
+
+--- Tell the proxy which scale to display in. The proxy defaults to Fahrenheit
+--- and never consults the project setting on its own, so without this a
+--- Celsius project still shows Fahrenheit thermostats.
+--- @return void
+local function sendDisplayScale()
+  local scale = getDisplayScale()
+  log:debug("Setting thermostat display scale to %s", scale)
+  SendToProxy(PROXY_BINDING, "SCALE_CHANGED", { SCALE = scale }, "NOTIFY")
+end
+
 --- Extract a Celsius temperature from proxy command params.
 --- The proxy sends CELSIUS, FAHRENHEIT, KELVIN, and SETPOINT simultaneously.
 --- @param tParams table Proxy command parameters.
@@ -337,6 +381,8 @@ end
 local function sendCapabilities(entity)
   log:trace("sendCapabilities(%s)", entity)
 
+  sendDisplayScale()
+
   -- HVAC modes: water heaters only support Off/Heat in C4; climate entities map from ESPHome modes
   if entity.is_water_heater then
     SendToProxy(PROXY_BINDING, "ALLOWED_HVAC_MODES_CHANGED", { MODES = "Off,Heat" }, "NOTIFY")
@@ -516,7 +562,7 @@ function OnDriverLateInit()
 
   gInitialized = true
   updateStatus("Disconnected", false)
-  SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = false }, "NOTIFY")
+  sendConnectionState(false)
   SendToProxy(ESPHOME_BINDING, "REFRESH_STATE", {}, "NOTIFY")
 end
 
@@ -860,6 +906,23 @@ function RFP.SET_MODE_HVAC(idBinding, strCommand, tParams)
   })
 end
 
+--- The proxy asks the driver to change the displayed units. ESPHome has no
+--- device-side scale to push this to, so the driver just records the override
+--- and reports the new scale back.
+function RFP.SET_SCALE(idBinding, strCommand, tParams)
+  log:trace("RFP.SET_SCALE(%s, %s, %s)", idBinding, strCommand, tParams)
+  if idBinding ~= PROXY_BINDING then
+    return
+  end
+  local scale = normalizeScale(Select(tParams, "SCALE"))
+  if scale == nil then
+    log:warn("Ignoring SET_SCALE with unrecognized scale: %s", Select(tParams, "SCALE"))
+    return
+  end
+  persist:set(P_DISPLAY_SCALE, scale)
+  sendDisplayScale()
+end
+
 function RFP.SET_SETPOINT_SINGLE(idBinding, strCommand, tParams)
   log:trace("RFP.SET_SETPOINT_SINGLE(%s, %s, %s)", idBinding, strCommand, tParams)
   if idBinding ~= PROXY_BINDING then
@@ -912,7 +975,7 @@ function RFP.UPDATE_DISCONNECT(idBinding, strCommand, tParams, args)
   IS_SINGLE_SETPOINT = false
   USER_SERVICES_DISCOVERED = false
   updateStatus("Disconnected", false)
-  SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = false }, "NOTIFY")
+  sendConnectionState(false)
 end
 
 --- Last unmapped mode/action warned about. State pushes repeat every few
@@ -943,7 +1006,7 @@ function RFP.UPDATE_STATE(idBinding, strCommand, tParams, args)
 
   -- Always update connection status
   updateStatus("Connected", true)
-  SendToProxy(PROXY_BINDING, "ONLINE_CHANGED", { STATE = true }, "NOTIFY")
+  sendConnectionState(true)
 
   -- Send capabilities on first state update
   if not CAPABILITIES_SENT then

--- a/drivers/esphome_climate/driver.lua
+++ b/drivers/esphome_climate/driver.lua
@@ -160,12 +160,23 @@ local function sendConnectionState(connected)
   SendToProxy(PROXY_BINDING, "CONNECTION", { CONNECTED = connected and "true" or "false" }, "NOTIFY")
 end
 
---- Tell the proxy which scale to display in. The proxy defaults to Fahrenheit
---- and never consults the project setting on its own, so without this a
---- Celsius project still shows Fahrenheit thermostats.
+--- Last scale reported to the proxy, so a change in the project's scale is
+--- picked up without waiting for the ESPHome device to reconnect.
+--- @type string|nil
+local REPORTED_SCALE = nil
+
+--- Tell the proxy which scale to display in, if it has changed. The proxy
+--- defaults to Fahrenheit and never consults the project setting on its own, so
+--- without this a Celsius project still shows Fahrenheit thermostats. Called on
+--- every state update, which is what lets an installer flip the project scale in
+--- Composer and see it take effect on an already-connected thermostat.
 --- @return void
 local function sendDisplayScale()
   local scale = getDisplayScale()
+  if scale == REPORTED_SCALE then
+    return
+  end
+  REPORTED_SCALE = scale
   log:debug("Setting thermostat display scale to %s", scale)
   SendToProxy(PROXY_BINDING, "SCALE_CHANGED", { SCALE = scale }, "NOTIFY")
 end
@@ -920,6 +931,7 @@ function RFP.SET_SCALE(idBinding, strCommand, tParams)
     return
   end
   persist:set(P_DISPLAY_SCALE, scale)
+  REPORTED_SCALE = nil
   sendDisplayScale()
 end
 
@@ -975,6 +987,7 @@ function RFP.UPDATE_DISCONNECT(idBinding, strCommand, tParams, args)
   IS_SINGLE_SETPOINT = false
   USER_SERVICES_DISCOVERED = false
   updateStatus("Disconnected", false)
+  REPORTED_SCALE = nil
   sendConnectionState(false)
 end
 
@@ -1011,6 +1024,9 @@ function RFP.UPDATE_STATE(idBinding, strCommand, tParams, args)
   -- Send capabilities on first state update
   if not CAPABILITIES_SENT then
     sendCapabilities(entity)
+  else
+    -- Cheap no-op unless the project scale changed under us.
+    sendDisplayScale()
   end
 
   -- Current temperature

--- a/drivers/esphome_climate/driver.lua
+++ b/drivers/esphome_climate/driver.lua
@@ -1025,7 +1025,9 @@ function RFP.UPDATE_STATE(idBinding, strCommand, tParams, args)
   if not CAPABILITIES_SENT then
     sendCapabilities(entity)
   else
-    -- Cheap no-op unless the project scale changed under us.
+    -- Re-reads the persisted override and the project scale, then notifies only
+    -- when the value changed. Two director round-trips per state update, which is
+    -- what buys picking up a project scale change without a reconnect.
     sendDisplayScale()
   end
 

--- a/drivers/esphome_climate/driver.lua
+++ b/drivers/esphome_climate/driver.lua
@@ -129,8 +129,8 @@ local SCALE = "C"
 --- Persist key for an installer's per-thermostat display-scale override.
 local P_DISPLAY_SCALE = "DisplayScale"
 
---- Normalize any of the scale spellings the proxy uses ("C"/"F",
---- "Celsius"/"Fahrenheit", "CELSIUS"/"FAHRENHEIT") to a single letter.
+--- The proxy and C4:GetTemperatureScale() disagree on spelling ("C" vs "Celsius"
+--- vs "CELSIUS"), so both are reduced to a letter.
 --- @param scale string|nil
 --- @return string|nil scale "C", "F", or nil if unrecognized.
 local function normalizeScale(scale)
@@ -141,35 +141,27 @@ local function normalizeScale(scale)
   return nil
 end
 
---- The scale the thermostat should display in. An installer override set from
---- Composer or programming (SET_SCALE) wins; otherwise follow the project's
---- temperature scale. ESPHome itself is always Celsius, so this is purely a
---- display concern and nothing is pushed to the device.
+--- An installer override wins over the project scale. ESPHome is always Celsius
+--- internally, so this only affects what Control4 displays.
 --- @return string scale "C" or "F".
 local function getDisplayScale()
   return normalizeScale(persist:get(P_DISPLAY_SCALE)) or normalizeScale(C4:GetTemperatureScale()) or "F"
 end
 
---- Report the ESPHome device's reachability to the thermostat proxy.
---- thermostatV2 has no ONLINE_CHANGED; it tracks reachability through
---- CONNECTION/CONNECTED, which drives the proxy's IS_CONNECTED variable and the
---- offline indicator Navigator shows on the thermostat.
+--- thermostatV2 has no ONLINE_CHANGED. It tracks reachability through
+--- CONNECTION/CONNECTED, which drives its IS_CONNECTED variable.
 --- @param connected boolean
 --- @return void
 local function sendConnectionState(connected)
   SendToProxy(PROXY_BINDING, "CONNECTION", { CONNECTED = connected and "true" or "false" }, "NOTIFY")
 end
 
---- Last scale reported to the proxy, so a change in the project's scale is
---- picked up without waiting for the ESPHome device to reconnect.
 --- @type string|nil
 local REPORTED_SCALE = nil
 
---- Tell the proxy which scale to display in, if it has changed. The proxy
---- defaults to Fahrenheit and never consults the project setting on its own, so
---- without this a Celsius project still shows Fahrenheit thermostats. Called on
---- every state update, which is what lets an installer flip the project scale in
---- Composer and see it take effect on an already-connected thermostat.
+--- The proxy defaults to Fahrenheit and never consults the project setting, so a
+--- Celsius project shows Fahrenheit thermostats without this. Called on every
+--- state update so a project scale change lands without a reconnect.
 --- @return void
 local function sendDisplayScale()
   local scale = getDisplayScale()
@@ -917,9 +909,7 @@ function RFP.SET_MODE_HVAC(idBinding, strCommand, tParams)
   })
 end
 
---- The proxy asks the driver to change the displayed units. ESPHome has no
---- device-side scale to push this to, so the driver just records the override
---- and reports the new scale back.
+--- ESPHome has no device-side scale to push this to, so record it and report back.
 function RFP.SET_SCALE(idBinding, strCommand, tParams)
   log:trace("RFP.SET_SCALE(%s, %s, %s)", idBinding, strCommand, tParams)
   if idBinding ~= PROXY_BINDING then
@@ -1025,9 +1015,7 @@ function RFP.UPDATE_STATE(idBinding, strCommand, tParams, args)
   if not CAPABILITIES_SENT then
     sendCapabilities(entity)
   else
-    -- Re-reads the persisted override and the project scale, then notifies only
-    -- when the value changed. Two director round-trips per state update, which is
-    -- what buys picking up a project scale change without a reconnect.
+    -- Two director reads per update; notifies only on an actual change.
     sendDisplayScale()
   end
 

--- a/drivers/esphome_climate/driver.lua
+++ b/drivers/esphome_climate/driver.lua
@@ -1015,7 +1015,6 @@ function RFP.UPDATE_STATE(idBinding, strCommand, tParams, args)
   if not CAPABILITIES_SENT then
     sendCapabilities(entity)
   else
-    -- Two director reads per update; notifies only on an actual change.
     sendDisplayScale()
   end
 

--- a/drivers/esphome_climate/driver.xml
+++ b/drivers/esphome_climate/driver.xml
@@ -108,6 +108,11 @@
     <can_preset>False</can_preset>
     <can_preset_schedule>False</can_preset_schedule>
     <has_temperature>True</has_temperature>
+    <!--
+      Lets the proxy surface the device's reachability. The driver keeps this in
+      step with the ESPHome connection through the CONNECTION notification.
+    -->
+    <has_connection_status>True</has_connection_status>
     <current_temperature_min_c>-50</current_temperature_min_c>
     <current_temperature_max_c>150</current_temperature_max_c>
     <current_temperature_min_f>-58</current_temperature_min_f>
@@ -131,7 +136,13 @@
     <setpoint_single_resolution_c>0.5</setpoint_single_resolution_c>
     <setpoint_single_resolution_f>1</setpoint_single_resolution_f>
     <can_inc_dec_setpoints>True</can_inc_dec_setpoints>
-    <can_change_scale>False</can_change_scale>
+    <!--
+      Not device-derived: ESPHome is always Celsius internally, so the scale is
+      purely what Control4 displays and the driver can always change it. True
+      keeps Composer's Celsius/Fahrenheit radio buttons live so an installer can
+      override the project-wide scale for one thermostat.
+    -->
+    <can_change_scale>True</can_change_scale>
     <has_extras>False</has_extras>
     <has_vacation_mode>False</has_vacation_mode>
     <has_remote_sensor>True</has_remote_sensor>

--- a/drivers/esphome_climate/driver.xml
+++ b/drivers/esphome_climate/driver.xml
@@ -108,10 +108,6 @@
     <can_preset>False</can_preset>
     <can_preset_schedule>False</can_preset_schedule>
     <has_temperature>True</has_temperature>
-    <!--
-      Lets the proxy surface the device's reachability. The driver keeps this in
-      step with the ESPHome connection through the CONNECTION notification.
-    -->
     <has_connection_status>True</has_connection_status>
     <current_temperature_min_c>-50</current_temperature_min_c>
     <current_temperature_max_c>150</current_temperature_max_c>
@@ -136,12 +132,7 @@
     <setpoint_single_resolution_c>0.5</setpoint_single_resolution_c>
     <setpoint_single_resolution_f>1</setpoint_single_resolution_f>
     <can_inc_dec_setpoints>True</can_inc_dec_setpoints>
-    <!--
-      Not device-derived: ESPHome is always Celsius internally, so the scale is
-      purely what Control4 displays and the driver can always change it. True
-      keeps Composer's Celsius/Fahrenheit radio buttons live so an installer can
-      override the project-wide scale for one thermostat.
-    -->
+    <!-- Display-only here, so the driver can always honour it. -->
     <can_change_scale>True</can_change_scale>
     <has_extras>False</has_extras>
     <has_vacation_mode>False</has_vacation_mode>

--- a/drivers/esphome_climate/www/documentation/index.md
+++ b/drivers/esphome_climate/www/documentation/index.md
@@ -77,8 +77,11 @@ thermostat proxy.
 - Water heater entity support with operating mode selection via extras
 - Remote temperature sensor support via ESPHome user-defined services
 - Dynamic capability reporting based on ESPHome device features
-- Temperature values communicated in Celsius - the C4 proxy handles display
-  conversion to the project's configured scale
+- Temperature values communicated in Celsius, displayed in the project's
+  temperature scale, with a per-thermostat Celsius/Fahrenheit override available
+  in Composer
+- Connection status reported to the thermostat proxy, so Navigator shows the
+  thermostat as unavailable while the ESPHome device is offline
 
 # <span style="color:#17BCF2">Compatibility</span>
 
@@ -173,6 +176,17 @@ remote sensor is disabled via the thermostat UI.
 Leave as `None` if your ESPHome device automatically reverts to its internal
 sensor when remote temperature updates stop (most devices have a configurable
 timeout for this).
+
+## Programming Variables
+
+| Variable  | Type | Description                                            |
+| --------- | ---- | ------------------------------------------------------ |
+| Connected | BOOL | True while the driver is talking to the ESPHome device |
+
+Use `Connected` in Programming to react to the device going offline, for example
+to drive a custom Navigator element or send a notification. The driver also
+reports its connection state to the Thermostat proxy, so Navigator marks the
+device unavailable on its own.
 
 ## Connections
 

--- a/drivers/esphome_fan/www/documentation/index.md
+++ b/drivers/esphome_fan/www/documentation/index.md
@@ -162,6 +162,17 @@ Sets the fan oscillation on or off. Available in Composer Pro programming.
 
 - **Oscillation** \[ **_True_** | False \] - Whether the fan should oscillate.
 
+## Programming Variables
+
+| Variable  | Type | Description                                         |
+| --------- | ---- | --------------------------------------------------- |
+| Connected | BOOL | True while the driver is talking to the ESPHome fan |
+
+Use `Connected` in Programming to react to the device going offline, for example
+to drive a custom Navigator element or send a notification. The driver also
+reports its connection state to the Fan proxy, so Navigator marks the device
+unavailable on its own.
+
 ## Connections
 
 ### Fan (provider)

--- a/drivers/esphome_govee/www/documentation/index.md
+++ b/drivers/esphome_govee/www/documentation/index.md
@@ -321,11 +321,12 @@ All sensor values are exposed as variables for programming:
 
 ### Common Variables
 
-| Variable    | Type   | Description                 |
-| ----------- | ------ | --------------------------- |
-| Name        | STRING | Device name                 |
-| Device Type | STRING | Detected Govee device model |
-| MAC Address | STRING | Device MAC address          |
+| Variable    | Type   | Description                        |
+| ----------- | ------ | ---------------------------------- |
+| Connected   | BOOL   | True while the device is reporting |
+| Name        | STRING | Device name                        |
+| Device Type | STRING | Detected Govee device model        |
+| MAC Address | STRING | Device MAC address                 |
 
 > **Note:** `Last Seen` and `RSSI` are read-only driver properties (see
 > [Device Info](#device-info)) and do not appear as programming variables.

--- a/drivers/esphome_light/driver.lua
+++ b/drivers/esphome_light/driver.lua
@@ -316,6 +316,13 @@ local function kelvinToMireds(k)
   return 1e6 / k
 end
 
+-- A transition rate in milliseconds, held inside the light_v2 rate bounds
+-- [0, 65535] so a stored default never falls outside the control's range.
+local function clampRate(ms)
+  ms = tonumber(ms) or 0
+  return math.max(0, math.min(65535, math.floor(ms + 0.5)))
+end
+
 local function updateDynamicCapabilities(entity)
   if dynamicCapsSent then
     return
@@ -350,12 +357,16 @@ local function updateDynamicCapabilities(entity)
     maxMireds
   )
 
-  -- Emit the FULL set of dynamic capabilities (everything spec'd as
-  -- "Dynamic Capability: Yes" in the LIGHT_V2 cap docs, plus dynamic-only
-  -- caps from DYNAMIC_CAPABILITIES_CHANGED). Composer reads these at
-  -- runtime to gate UI elements; the static driver.xml values are only
-  -- the design-time defaults. Emitting the full set ensures Navigators
-  -- and Composer test panels reflect the actual bulb's capabilities.
+  -- Report the bound light's ACTUAL capabilities. DYNAMIC_CAPABILITIES_CHANGED is
+  -- the authoritative full set the proxy relays onward, and a numeric cap left out
+  -- of it is relayed as 0 rather than falling back to the static driver.xml. So
+  -- every rate control's bounds and default ride EVERY send, unconditionally, even
+  -- when the light has no color at all; the supports_* flags, not missing bounds,
+  -- are what gate a control's visibility. A color-rate control left at 0/0 bounds
+  -- plus the proxy's built-in 750 ms seed is exactly the "defaultColorRate ...
+  -- value 0.750 not between 0.000 and 0.000" crash Composer throws at bind.
+  local brightnessRateDefault = clampRate(persist:get(P_RATE_DEFAULT, DEFAULT_RATE))
+  local colorRateDefault = clampRate(persist:get(P_COLOR_RATE_DEFAULT, brightnessRateDefault))
   local caps = {
     -- Brightness/dimmer
     dimmer = supportsDimming,
@@ -367,9 +378,15 @@ local function updateDynamicCapabilities(entity)
     fixed_ramp_rate = 0,
     brightness_rate_min = 0,
     brightness_rate_max = 65535,
-    -- Color
+    brightness_rate_default = brightnessRateDefault,
+    -- Color: bounds and default are always present (see above); only the flags gate.
     supports_color = supportsColor,
     supports_color_correlated_temperature = supportsCCT,
+    supports_color_stop = supportsColor or supportsCCT,
+    color_rate_behavior = 1, -- ESPHome's transition_length applies to all aspects equally
+    color_rate_min = 0,
+    color_rate_max = 65535,
+    color_rate_default = colorRateDefault,
     -- Misc
     has_extras = false,
     cold_start = false,
@@ -379,14 +396,6 @@ local function updateDynamicCapabilities(entity)
     -- CIE mireds invert vs Kelvin, so swap min/max during conversion.
     caps.color_correlated_temperature_min = miredsToKelvin(maxMireds)
     caps.color_correlated_temperature_max = miredsToKelvin(minMireds)
-  end
-  if supportsColor or supportsCCT then
-    caps.color_rate_behavior = 1 -- ESPHome's transition_length applies to all aspects equally
-    caps.color_rate_min = 0
-    caps.color_rate_max = 65535
-    caps.supports_color_stop = true
-  else
-    caps.supports_color_stop = false
   end
   SendToProxy(PROXY_BINDING, "DYNAMIC_CAPABILITIES_CHANGED", caps, "NOTIFY", true)
 

--- a/drivers/esphome_light/driver.lua
+++ b/drivers/esphome_light/driver.lua
@@ -316,13 +316,6 @@ local function kelvinToMireds(k)
   return 1e6 / k
 end
 
--- A transition rate in milliseconds, held inside the light_v2 rate bounds
--- [0, 65535] so a stored default never falls outside the control's range.
-local function clampRate(ms)
-  ms = tonumber(ms) or 0
-  return math.max(0, math.min(65535, math.floor(ms + 0.5)))
-end
-
 local function updateDynamicCapabilities(entity)
   if dynamicCapsSent then
     return
@@ -358,17 +351,16 @@ local function updateDynamicCapabilities(entity)
   )
 
   -- Report the bound light's ACTUAL capabilities. The proxy merges this over the
-  -- static driver.xml values, so a light that reports brightness ends up dimmable
-  -- even though the XML declares dimmer=False.
+  -- static driver.xml values and this wins, in both directions: the dimming tier
+  -- is declared True statically for Composer's test panel, so the case that
+  -- matters here is a light without brightness being corrected back down.
   --
-  -- Every rate control's bounds and default ride EVERY send, unconditionally, even
-  -- when the light has no color at all. What gates a control's visibility is the
-  -- supports_* flags, not the presence of bounds, so sending them always costs
-  -- nothing and leaves no window in which a consumer can see a color rate control
-  -- with no range - which is the shape of the "defaultColorRate ... value 0.750
-  -- not between 0.000 and 0.000" exception Composer throws at bind.
-  local brightnessRateDefault = clampRate(persist:get(P_RATE_DEFAULT, DEFAULT_RATE))
-  local colorRateDefault = clampRate(persist:get(P_COLOR_RATE_DEFAULT, brightnessRateDefault))
+  -- The color rate bounds ride EVERY send, unconditionally, even when the light
+  -- has no color at all. What gates a control's visibility is the supports_*
+  -- flags, not the presence of bounds, so sending them always costs nothing and
+  -- leaves no window in which a consumer sees a color rate control with no range,
+  -- which is the shape of the "defaultColorRate ... value 0.750 not between 0.000
+  -- and 0.000" exception Composer throws at bind.
   local caps = {
     -- Brightness/dimmer
     dimmer = supportsDimming,
@@ -380,15 +372,13 @@ local function updateDynamicCapabilities(entity)
     fixed_ramp_rate = 0,
     brightness_rate_min = 0,
     brightness_rate_max = 65535,
-    brightness_rate_default = brightnessRateDefault,
-    -- Color: bounds and default are always present (see above); only the flags gate.
+    -- Color: the bounds are always present (see above); only the flags gate.
     supports_color = supportsColor,
     supports_color_correlated_temperature = supportsCCT,
     supports_color_stop = supportsColor or supportsCCT,
     color_rate_behavior = 1, -- ESPHome's transition_length applies to all aspects equally
     color_rate_min = 0,
     color_rate_max = 65535,
-    color_rate_default = colorRateDefault,
     -- Misc
     has_extras = false,
     cold_start = false,

--- a/drivers/esphome_light/driver.lua
+++ b/drivers/esphome_light/driver.lua
@@ -350,29 +350,20 @@ local function updateDynamicCapabilities(entity)
     maxMireds
   )
 
-  -- Report the bound light's ACTUAL capabilities. The proxy merges this over the
-  -- static driver.xml values and this wins, in both directions: the dimming tier
-  -- is declared True statically for Composer's test panel, so the case that
-  -- matters here is a light without brightness being corrected back down.
-  --
-  -- The color rate bounds ride EVERY send, unconditionally, even when the light
-  -- has no color at all. What gates a control's visibility is the supports_*
-  -- flags, not the presence of bounds, so sending them always costs nothing and
-  -- leaves no window in which a consumer sees a color rate control with no range,
-  -- which is the shape of the "defaultColorRate ... value 0.750 not between 0.000
-  -- and 0.000" exception Composer throws at bind.
+  -- The color rate bounds ride every send even on a light with no color: the
+  -- supports_* flags gate a control's visibility, and bounds relayed as 0/0 are
+  -- what makes Composer throw at bind.
   local caps = {
     -- Brightness/dimmer
     dimmer = supportsDimming,
     set_level = supportsDimming,
     supports_target = supportsDimming,
     supports_brightness_stop = supportsDimming,
-    ramp_level = supportsDimming, -- legacy 3.2-era cap; still gates test panel Ramp button
+    ramp_level = supportsDimming,
     has_fixed_ramp_rate = false,
     fixed_ramp_rate = 0,
     brightness_rate_min = 0,
     brightness_rate_max = 65535,
-    -- Color: the bounds are always present (see above); only the flags gate.
     supports_color = supportsColor,
     supports_color_correlated_temperature = supportsCCT,
     supports_color_stop = supportsColor or supportsCCT,

--- a/drivers/esphome_light/driver.lua
+++ b/drivers/esphome_light/driver.lua
@@ -357,14 +357,16 @@ local function updateDynamicCapabilities(entity)
     maxMireds
   )
 
-  -- Report the bound light's ACTUAL capabilities. DYNAMIC_CAPABILITIES_CHANGED is
-  -- the authoritative full set the proxy relays onward, and a numeric cap left out
-  -- of it is relayed as 0 rather than falling back to the static driver.xml. So
-  -- every rate control's bounds and default ride EVERY send, unconditionally, even
-  -- when the light has no color at all; the supports_* flags, not missing bounds,
-  -- are what gate a control's visibility. A color-rate control left at 0/0 bounds
-  -- plus the proxy's built-in 750 ms seed is exactly the "defaultColorRate ...
-  -- value 0.750 not between 0.000 and 0.000" crash Composer throws at bind.
+  -- Report the bound light's ACTUAL capabilities. The proxy merges this over the
+  -- static driver.xml values, so a light that reports brightness ends up dimmable
+  -- even though the XML declares dimmer=False.
+  --
+  -- Every rate control's bounds and default ride EVERY send, unconditionally, even
+  -- when the light has no color at all. What gates a control's visibility is the
+  -- supports_* flags, not the presence of bounds, so sending them always costs
+  -- nothing and leaves no window in which a consumer can see a color rate control
+  -- with no range - which is the shape of the "defaultColorRate ... value 0.750
+  -- not between 0.000 and 0.000" exception Composer throws at bind.
   local brightnessRateDefault = clampRate(persist:get(P_RATE_DEFAULT, DEFAULT_RATE))
   local colorRateDefault = clampRate(persist:get(P_COLOR_RATE_DEFAULT, brightnessRateDefault))
   local caps = {

--- a/drivers/esphome_light/driver.xml
+++ b/drivers/esphome_light/driver.xml
@@ -134,8 +134,8 @@
     <brightness_rate_max>65535</brightness_rate_max>
     <!--
       Not light_v2 capabilities; the proxy ignores both and still seeds its own
-      750 ms rate. Kept only for parity with Chowmain's ESPHome light, since
-      Composer reads this list directly. The color rate bounds sent from
+      750 ms rate. Declared because Composer reads this list directly and may
+      seed its own rate control from it. The color rate bounds sent from
       driver.lua are what prevent the bind-time throw.
     -->
     <brightness_rate_default>0</brightness_rate_default>

--- a/drivers/esphome_light/driver.xml
+++ b/drivers/esphome_light/driver.xml
@@ -88,22 +88,20 @@
     <actions/>
   </config>
   <!--
-    Static floor, used until the bound ESPHome light is discovered. Every
-    capability the light_v2 proxy accepts via DYNAMIC_CAPABILITIES_CHANGED is
-    declared at its "off" value here and turned on from discovery; the ones the
-    proxy only reads statically (dimmer, set_level, ramp_level, on_off) must
-    stand on their own, because nothing at runtime can raise them.
+    Static floor, used until the bound ESPHome light is discovered. Everything
+    the driver reports dynamically is declared at its "off" value here and
+    raised from discovery, so an undiscovered or offline light never advertises
+    a capability it may not have.
+
+    dimmer, set_level and ramp_level are genuinely dynamic: with False here and
+    a dynamic dimmer=true, the proxy's own GET_SETUP reports dimmer=True,
+    ramp_level=True and supports_target=True (verified on a CORE 1). They stay
+    False so consumers that read the static list - C4:GetDeviceData(id,
+    "capabilities") - do not see every ESPHome light as dimmable.
   -->
   <capabilities>
-    <!--
-      dimmer/set_level/ramp_level are read only from this static list - they are
-      not in the proxy's dynamic capability set - so declaring them False would
-      permanently grey out Composer's dimming controls even for a light that
-      reports brightness support. The runtime dimmer state a Navigator sees comes
-      from the dynamic supports_target/dimmer pair instead.
-    -->
-    <dimmer>True</dimmer>
-    <set_level>True</set_level>
+    <dimmer>False</dimmer>
+    <set_level>False</set_level>
     <supports_target>False</supports_target>
     <supports_brightness_stop>False</supports_brightness_stop>
     <!--
@@ -114,7 +112,7 @@
       the Default On preset editor including its Inactive Color picker.
     -->
     <on_off>True</on_off>
-    <ramp_level>True</ramp_level>
+    <ramp_level>False</ramp_level>
     <supports_default_on>True</supports_default_on>
     <!--
       has_fixed_ramp_rate=true means the bulb has a fixed ramp rate that
@@ -149,10 +147,13 @@
     <brightness_rate_min>0</brightness_rate_min>
     <brightness_rate_max>65535</brightness_rate_max>
     <!--
-      The proxy seeds a built-in 750 ms rate default at bind time, before our
-      dynamic capabilities arrive. Seeding 0 here keeps that value inside
-      whatever bounds Composer has loaded so binding never throws
-      "defaultColorRate ... value 0.750 not between 0.000 and 0.000".
+      The proxy seeds a built-in 750 ms rate default at bind time, before any
+      dynamic capabilities arrive. It ignores these two entries - there is no
+      such capability in light_v2, and a fresh install still seeds 750 - but
+      Composer reads the static capability list directly and may use them to
+      seed its own rate control, which is where the
+      "defaultColorRate ... value 0.750 not between 0.000 and 0.000" throw
+      happens. Kept at 0 as cheap insurance on the Composer side.
     -->
     <brightness_rate_default>0</brightness_rate_default>
     <click_rate_min>0</click_rate_min>

--- a/drivers/esphome_light/driver.xml
+++ b/drivers/esphome_light/driver.xml
@@ -90,20 +90,41 @@
   <!--
     Static floor, used until the bound ESPHome light is discovered. Everything
     the driver reports dynamically is declared at its "off" value here and
-    raised from discovery, so an undiscovered or offline light never advertises
-    a capability it may not have.
+    raised from discovery, except the capabilities Composer's test panel gates
+    on, which are noted below.
 
-    dimmer, set_level and ramp_level are genuinely dynamic: with False here and
-    a dynamic dimmer=true, the proxy's own GET_SETUP reports dimmer=True,
-    ramp_level=True and supports_target=True (verified on a CORE 1). They stay
-    False so consumers that read the static list - C4:GetDeviceData(id,
-    "capabilities") - do not see every ESPHome light as dimmable.
+    All of these are dynamic and a dynamic value overrides them in both
+    directions, but consumers read the static/dynamic pair differently.
+    Measured on a CORE 1 across all four static/dynamic combinations:
+
+      Composer properties tab   follows the dynamic value alone
+      Navigator / the app       follows the dynamic value alone
+      Composer test panel       needs static AND dynamic true, but only for
+                                the dimming tier - the color picker and color
+                                temperature controls came up usable with
+                                supports_color / _correlated_temperature False
+
+    So the dimming tier is True here and the color tier is False. True costs
+    nothing on a light that is not dimmable: it reports a dynamic dimmer=false
+    and is correctly greyed out in Composer and slider-less in the app whatever
+    this says. Two comparable hub-backed light_v2 drivers land the same way -
+    Matter Light declares dimmer/set_level/supports_target True with the color
+    capabilities False, and Chowmain's ESPHome Light declares
+    set_level/ramp_level/supports_target true and omits the color ones.
+
+    The one consumer this misleads is code that reads the static list via
+    C4:GetDeviceData(id, "capabilities") and falls back to it with `or`, which
+    cannot tell "declared false" from "not declared". That is a consumer-side
+    bug, tracked in DRV-113. It reads dimmer, set_level and ramp_level, which is
+    the cost of this; it also reads supports_color and
+    supports_color_correlated_temperature, which is a further reason to leave
+    the color tier alone.
   -->
   <capabilities>
-    <dimmer>False</dimmer>
-    <set_level>False</set_level>
-    <supports_target>False</supports_target>
-    <supports_brightness_stop>False</supports_brightness_stop>
+    <dimmer>True</dimmer>
+    <set_level>True</set_level>
+    <supports_target>True</supports_target>
+    <supports_brightness_stop>True</supports_brightness_stop>
     <!--
       on_off, ramp_level, and supports_default_on are documented as
       "deprecated in 3.3.2" but Composer's test panel still gates UI
@@ -112,7 +133,7 @@
       the Default On preset editor including its Inactive Color picker.
     -->
     <on_off>True</on_off>
-    <ramp_level>False</ramp_level>
+    <ramp_level>True</ramp_level>
     <supports_default_on>True</supports_default_on>
     <!--
       has_fixed_ramp_rate=true means the bulb has a fixed ramp rate that

--- a/drivers/esphome_light/driver.xml
+++ b/drivers/esphome_light/driver.xml
@@ -87,9 +87,23 @@
     <commands/>
     <actions/>
   </config>
+  <!--
+    Static floor, used until the bound ESPHome light is discovered. Every
+    capability the light_v2 proxy accepts via DYNAMIC_CAPABILITIES_CHANGED is
+    declared at its "off" value here and turned on from discovery; the ones the
+    proxy only reads statically (dimmer, set_level, ramp_level, on_off) must
+    stand on their own, because nothing at runtime can raise them.
+  -->
   <capabilities>
-    <dimmer>False</dimmer>
-    <set_level>False</set_level>
+    <!--
+      dimmer/set_level/ramp_level are read only from this static list - they are
+      not in the proxy's dynamic capability set - so declaring them False would
+      permanently grey out Composer's dimming controls even for a light that
+      reports brightness support. The runtime dimmer state a Navigator sees comes
+      from the dynamic supports_target/dimmer pair instead.
+    -->
+    <dimmer>True</dimmer>
+    <set_level>True</set_level>
     <supports_target>False</supports_target>
     <supports_brightness_stop>False</supports_brightness_stop>
     <!--
@@ -100,7 +114,7 @@
       the Default On preset editor including its Inactive Color picker.
     -->
     <on_off>True</on_off>
-    <ramp_level>False</ramp_level>
+    <ramp_level>True</ramp_level>
     <supports_default_on>True</supports_default_on>
     <!--
       has_fixed_ramp_rate=true means the bulb has a fixed ramp rate that
@@ -134,6 +148,13 @@
     <disable_flash>False</disable_flash>
     <brightness_rate_min>0</brightness_rate_min>
     <brightness_rate_max>65535</brightness_rate_max>
+    <!--
+      The proxy seeds a built-in 750 ms rate default at bind time, before our
+      dynamic capabilities arrive. Seeding 0 here keeps that value inside
+      whatever bounds Composer has loaded so binding never throws
+      "defaultColorRate ... value 0.750 not between 0.000 and 0.000".
+    -->
+    <brightness_rate_default>0</brightness_rate_default>
     <click_rate_min>0</click_rate_min>
     <click_rate_max>65535</click_rate_max>
     <hold_rate_min>1000</hold_rate_min>
@@ -146,6 +167,7 @@
     <color_rate_behavior>1</color_rate_behavior>
     <color_rate_min>0</color_rate_min>
     <color_rate_max>65535</color_rate_max>
+    <color_rate_default>0</color_rate_default>
   </capabilities>
   <proxies>
     <proxy proxybindingid="5001" primary="True" name="ESPHome Light">light_v2</proxy>

--- a/drivers/esphome_light/driver.xml
+++ b/drivers/esphome_light/driver.xml
@@ -88,37 +88,12 @@
     <actions/>
   </config>
   <!--
-    Static floor, used until the bound ESPHome light is discovered. Everything
-    the driver reports dynamically is declared at its "off" value here and
-    raised from discovery, except the capabilities Composer's test panel gates
-    on, which are noted below.
-
-    All of these are dynamic and a dynamic value overrides them in both
-    directions, but consumers read the static/dynamic pair differently.
-    Measured on a CORE 1 across all four static/dynamic combinations:
-
-      Composer properties tab   follows the dynamic value alone
-      Navigator / the app       follows the dynamic value alone
-      Composer test panel       needs static AND dynamic true, but only for
-                                the dimming tier - the color picker and color
-                                temperature controls came up usable with
-                                supports_color / _correlated_temperature False
-
-    So the dimming tier is True here and the color tier is False. True costs
-    nothing on a light that is not dimmable: it reports a dynamic dimmer=false
-    and is correctly greyed out in Composer and slider-less in the app whatever
-    this says. Two comparable hub-backed light_v2 drivers land the same way -
-    Matter Light declares dimmer/set_level/supports_target True with the color
-    capabilities False, and Chowmain's ESPHome Light declares
-    set_level/ramp_level/supports_target true and omits the color ones.
-
-    The one consumer this misleads is code that reads the static list via
-    C4:GetDeviceData(id, "capabilities") and falls back to it with `or`, which
-    cannot tell "declared false" from "not declared". That is a consumer-side
-    bug, tracked in DRV-113. It reads dimmer, set_level and ramp_level, which is
-    the cost of this; it also reads supports_color and
-    supports_color_correlated_temperature, which is a further reason to leave
-    the color tier alone.
+    A dynamic capability overrides these in both directions, so discovery
+    corrects a light that lacks one back down. The dimming tier is True anyway
+    because Composer's test panel needs static AND dynamic; the color tier does
+    not, so it stays off. Cost of the dimming tier: consumers that read this list
+    with an `or` fallback cannot tell a declared False from an undeclared one and
+    see every light as dimmable (DRV-113).
   -->
   <capabilities>
     <dimmer>True</dimmer>
@@ -126,23 +101,13 @@
     <supports_target>True</supports_target>
     <supports_brightness_stop>True</supports_brightness_stop>
     <!--
-      on_off, ramp_level, and supports_default_on are documented as
-      "deprecated in 3.3.2" but Composer's test panel still gates UI
-      elements on them: on_off enables the On/Off level buttons;
-      ramp_level enables the Ramp button; supports_default_on enables
-      the Default On preset editor including its Inactive Color picker.
+      Deprecated in 3.3.2, but Composer's test panel still gates on them: the
+      On/Off buttons, the Ramp button, and the Default On preset editor.
     -->
     <on_off>True</on_off>
     <ramp_level>True</ramp_level>
     <supports_default_on>True</supports_default_on>
-    <!--
-      has_fixed_ramp_rate=true means the bulb has a fixed ramp rate that
-      cannot be changed; we want the user to set rates so this is false.
-      fixed_ramp_rate=0 is the placeholder when has_fixed_ramp_rate=false.
-      Default is false but we declare explicitly because Composer's test
-      panel UI gating sometimes treats undeclared caps differently than
-      declared-as-default.
-    -->
+    <!-- True would mean the bulb's ramp rate cannot be changed. -->
     <has_fixed_ramp_rate>False</has_fixed_ramp_rate>
     <fixed_ramp_rate>0</fixed_ramp_rate>
     <hide_proxy_properties>False</hide_proxy_properties>
@@ -168,15 +133,10 @@
     <brightness_rate_min>0</brightness_rate_min>
     <brightness_rate_max>65535</brightness_rate_max>
     <!--
-      brightness_rate_default and color_rate_default are not light_v2
-      capabilities at all: neither key appears in the proxy, and a fresh install
-      declaring them still seeds the proxy's built-in 750 ms rate. They are kept
-      only because Composer reads this static list directly and Chowmain's
-      ESPHome light ships the same two entries, so they are cheap parity rather
-      than a mechanism. What actually prevents the
-      "defaultColorRate ... value 0.750 not between 0.000 and 0.000" throw is
-      color_rate_min / color_rate_max riding every DYNAMIC_CAPABILITIES_CHANGED
-      in driver.lua, so the bounds are never relayed as 0/0.
+      Not light_v2 capabilities; the proxy ignores both and still seeds its own
+      750 ms rate. Kept only for parity with Chowmain's ESPHome light, since
+      Composer reads this list directly. The color rate bounds sent from
+      driver.lua are what prevent the bind-time throw.
     -->
     <brightness_rate_default>0</brightness_rate_default>
     <click_rate_min>0</click_rate_min>

--- a/drivers/esphome_light/driver.xml
+++ b/drivers/esphome_light/driver.xml
@@ -168,13 +168,15 @@
     <brightness_rate_min>0</brightness_rate_min>
     <brightness_rate_max>65535</brightness_rate_max>
     <!--
-      The proxy seeds a built-in 750 ms rate default at bind time, before any
-      dynamic capabilities arrive. It ignores these two entries - there is no
-      such capability in light_v2, and a fresh install still seeds 750 - but
-      Composer reads the static capability list directly and may use them to
-      seed its own rate control, which is where the
-      "defaultColorRate ... value 0.750 not between 0.000 and 0.000" throw
-      happens. Kept at 0 as cheap insurance on the Composer side.
+      brightness_rate_default and color_rate_default are not light_v2
+      capabilities at all: neither key appears in the proxy, and a fresh install
+      declaring them still seeds the proxy's built-in 750 ms rate. They are kept
+      only because Composer reads this static list directly and Chowmain's
+      ESPHome light ships the same two entries, so they are cheap parity rather
+      than a mechanism. What actually prevents the
+      "defaultColorRate ... value 0.750 not between 0.000 and 0.000" throw is
+      color_rate_min / color_rate_max riding every DYNAMIC_CAPABILITIES_CHANGED
+      in driver.lua, so the bounds are never relayed as 0/0.
     -->
     <brightness_rate_default>0</brightness_rate_default>
     <click_rate_min>0</click_rate_min>

--- a/drivers/esphome_light/www/documentation/index.md
+++ b/drivers/esphome_light/www/documentation/index.md
@@ -146,6 +146,17 @@ Sets the logging level. Default is `3 - Info`.
 
 Sets the logging mode. Default is `Off`.
 
+## Programming Variables
+
+| Variable  | Type | Description                                           |
+| --------- | ---- | ----------------------------------------------------- |
+| Connected | BOOL | True while the driver is talking to the ESPHome light |
+
+Use `Connected` in Programming to react to the device going offline, for example
+to drive a custom Navigator element or send a notification. The driver also
+reports its connection state to the Light proxy, so Navigator marks the device
+unavailable on its own.
+
 ## Connections
 
 ### Light (provider)

--- a/drivers/esphome_lock/www/documentation/index.md
+++ b/drivers/esphome_lock/www/documentation/index.md
@@ -125,6 +125,17 @@ Sets the logging mode. Default is `Off`.
 Code sent with lock and unlock commands. Leave blank if the device does not
 require a code.
 
+## Programming Variables
+
+| Variable  | Type | Description                                          |
+| --------- | ---- | ---------------------------------------------------- |
+| Connected | BOOL | True while the driver is talking to the ESPHome lock |
+
+Use `Connected` in Programming to react to the lock going offline, for example
+to drive a custom Navigator element or send a notification. The Lock proxy has
+no connection-status notification of its own, so this variable is the way to
+surface it.
+
 ## Connections
 
 ### Lock (provider)

--- a/drivers/esphome_switchbot/www/documentation/index.md
+++ b/drivers/esphome_switchbot/www/documentation/index.md
@@ -448,13 +448,14 @@ The following variables are available for programming (varies by device type):
 
 ### Common Variables
 
-| Variable    | Type   | Devices      | Description          |
-| ----------- | ------ | ------------ | -------------------- |
-| Battery     | NUMBER | Most devices | Battery level (%)    |
-| Battery Low | STRING | Water Leak   | Low battery status   |
-| Device Type | STRING | All          | Detected device type |
-| MAC Address | STRING | All          | Device MAC address   |
-| Name        | STRING | All          | Device name          |
+| Variable    | Type   | Devices      | Description                        |
+| ----------- | ------ | ------------ | ---------------------------------- |
+| Connected   | BOOL   | All          | True while the device is reporting |
+| Battery     | NUMBER | Most devices | Battery level (%)                  |
+| Battery Low | STRING | Water Leak   | Low battery status                 |
+| Device Type | STRING | All          | Detected device type               |
+| MAC Address | STRING | All          | Device MAC address                 |
+| Name        | STRING | All          | Device name                        |
 
 ### Bot Variables
 

--- a/drivers/esphome_yale/www/documentation/index.md
+++ b/drivers/esphome_yale/www/documentation/index.md
@@ -430,11 +430,12 @@ The driver exposes the following variables to Control4 programming. These mirror
 the matching read-only Device Info properties and can be used in programming
 conditions and event handlers.
 
-| Variable    | Type   | Description                        |
-| ----------- | ------ | ---------------------------------- |
-| Battery     | NUMBER | Lock battery level (0 - 100)       |
-| Name        | STRING | Friendly name reported by the lock |
-| MAC Address | STRING | Lock BLE MAC address               |
+| Variable    | Type   | Description                                  |
+| ----------- | ------ | -------------------------------------------- |
+| Connected   | BOOL   | True while the driver is talking to the lock |
+| Battery     | NUMBER | Lock battery level (0 - 100)                 |
+| Name        | STRING | Friendly name reported by the lock           |
+| MAC Address | STRING | Lock BLE MAC address                         |
 
 ## Connections
 

--- a/test/c4_shim.lua
+++ b/test/c4_shim.lua
@@ -30,6 +30,11 @@ function C4:GetDeviceData(deviceId, key)
   end
   return nil
 end
+-- The controller returns the project's temperature scale as a full word, not a
+-- single letter, so callers have to normalize it.
+function C4:GetTemperatureScale()
+  return "FAHRENHEIT"
+end
 function C4:AllowExecute() end
 function C4:UpdateProperty() end
 function C4:SetPropertyAttribs() end

--- a/test/c4_shim.lua
+++ b/test/c4_shim.lua
@@ -30,11 +30,9 @@ function C4:GetDeviceData(deviceId, key)
   end
   return nil
 end
--- The controller returns the project's temperature scale as a full word, not a
--- single letter, so callers have to normalize it. Mutable so a test can flip the
--- project scale mid-run, and Celsius by default: a caller that fails to
--- normalize falls through to its own Fahrenheit default, so only a Celsius
--- project tells a working normalizer apart from a broken one.
+-- The controller returns a full word, not a letter. Celsius by default because a
+-- caller that fails to normalize falls back to Fahrenheit, so only Celsius tells
+-- a working normalizer from a broken one. Mutable so a test can flip it mid-run.
 C4.TemperatureScale = "CELSIUS"
 function C4:GetTemperatureScale()
   return C4.TemperatureScale

--- a/test/c4_shim.lua
+++ b/test/c4_shim.lua
@@ -31,9 +31,13 @@ function C4:GetDeviceData(deviceId, key)
   return nil
 end
 -- The controller returns the project's temperature scale as a full word, not a
--- single letter, so callers have to normalize it.
+-- single letter, so callers have to normalize it. Mutable so a test can flip the
+-- project scale mid-run, and Celsius by default: a caller that fails to
+-- normalize falls through to its own Fahrenheit default, so only a Celsius
+-- project tells a working normalizer apart from a broken one.
+C4.TemperatureScale = "CELSIUS"
 function C4:GetTemperatureScale()
-  return "FAHRENHEIT"
+  return C4.TemperatureScale
 end
 function C4:AllowExecute() end
 function C4:UpdateProperty() end

--- a/test/dummy_buttons.yaml
+++ b/test/dummy_buttons.yaml
@@ -1,0 +1,132 @@
+# Host-mode ESPHome mock for the keypad/button direction work (issue #103).
+#
+# Models a 3-gang smart switch the way ESPHome actually exposes one:
+#   - switch  x3   the relays (gang 1/2 wired to their load, gang 3 decoupled)
+#   - binary_sensor x3   the physical paddles behind each gang
+#   - event   x1   a paddle exposed via the modern `event` entity instead
+#   - button  x1   a device-side action (an ESPHome `button` is an actuator you
+#                  press FROM the controller, NOT a paddle that reports presses)
+#   - light   x1   the gang-3 status LED, to test pushing C4 LED feedback back
+#
+# The point of the mock is the direction of each binding: a paddle must drive
+# Control4 loads (keypad role) while an ESPHome `button` must be pressable from
+# Control4 (load role).
+#
+# Usage:
+#   esphome compile test/dummy_buttons.yaml
+#   .esphome/build/dummy-buttons/.pioenvs/dummy-buttons/program
+#
+# API services:
+#   - paddle_press(gang)     paddle down then up on gang 1-3 (binary_sensor)
+#   - paddle_hold(gang)      paddle down, stays down until paddle_release
+#   - paddle_release(gang)   paddle up
+#   - fire_event(kind)       fire press/double_press/long_press on the event entity
+
+esphome:
+  name: dummy-buttons
+  friendly_name: Dummy Buttons
+
+host:
+
+logger:
+  level: DEBUG
+
+api:
+  port: 6054
+  services:
+    - service: paddle_press
+      variables:
+        gang: int
+      then:
+        - lambda: |-
+            ESP_LOGI("paddle", "press gang %d", gang);
+            if (gang == 1) { id(paddle_1).publish_state(true); id(paddle_1).publish_state(false); }
+            if (gang == 2) { id(paddle_2).publish_state(true); id(paddle_2).publish_state(false); }
+            if (gang == 3) { id(paddle_3).publish_state(true); id(paddle_3).publish_state(false); }
+    - service: paddle_hold
+      variables:
+        gang: int
+      then:
+        - lambda: |-
+            ESP_LOGI("paddle", "hold gang %d", gang);
+            if (gang == 1) { id(paddle_1).publish_state(true); }
+            if (gang == 2) { id(paddle_2).publish_state(true); }
+            if (gang == 3) { id(paddle_3).publish_state(true); }
+    - service: paddle_release
+      variables:
+        gang: int
+      then:
+        - lambda: |-
+            ESP_LOGI("paddle", "release gang %d", gang);
+            if (gang == 1) { id(paddle_1).publish_state(false); }
+            if (gang == 2) { id(paddle_2).publish_state(false); }
+            if (gang == 3) { id(paddle_3).publish_state(false); }
+    - service: fire_event
+      variables:
+        kind: string
+      then:
+        - lambda: |-
+            ESP_LOGI("paddle", "event %s", kind.c_str());
+            id(paddle_3_event).trigger(kind);
+
+output:
+  - platform: template
+    id: out_gang3_led
+    type: float
+    write_action:
+      - lambda: 'ESP_LOGI("led", "gang3 led -> %.3f", state);'
+
+switch:
+  - platform: template
+    name: "Gang 1 Relay"
+    id: gang_1_relay
+    optimistic: true
+    restore_mode: ALWAYS_OFF
+  - platform: template
+    name: "Gang 2 Relay"
+    id: gang_2_relay
+    optimistic: true
+    restore_mode: ALWAYS_OFF
+  - platform: template
+    name: "Gang 3 Relay"
+    id: gang_3_relay
+    optimistic: true
+    restore_mode: ALWAYS_OFF
+
+binary_sensor:
+  - platform: template
+    name: "Gang 1 Paddle"
+    id: paddle_1
+    device_class: ""
+  - platform: template
+    name: "Gang 2 Paddle"
+    id: paddle_2
+    device_class: ""
+  - platform: template
+    name: "Gang 3 Paddle"
+    id: paddle_3
+    device_class: ""
+
+event:
+  - platform: template
+    name: "Gang 3 Paddle Event"
+    id: paddle_3_event
+    device_class: button
+    event_types:
+      - "press"
+      - "double_press"
+      - "long_press"
+
+button:
+  - platform: template
+    name: "Identify"
+    id: identify_button
+    on_press:
+      - lambda: 'ESP_LOGI("button", "Identify pressed from the controller");'
+
+light:
+  - platform: monochromatic
+    name: "Gang 3 LED"
+    id: gang_3_led
+    output: out_gang3_led
+    default_transition_length: 0s


### PR DESCRIPTION
Closes #100, closes #101, closes #102.

Each root cause was reproduced and verified against a live CORE 1 with host-mode
ESPHome mocks, not inferred from the reports.

## #100 - thermostat shows Fahrenheit in a Celsius project

Not `can_change_scale`, as suggested on the issue. The `thermostatV2` proxy keeps
its **own** per-thermostat display scale that defaults to Fahrenheit and never
consults `project_settings.scale`; the driver never told it otherwise.

Verified live: sending `SCALE_CHANGED { SCALE = "C" }` flips proxy variable 1100
`SCALE` to `CELSIUS` and recomputes `DISPLAY_TEMPERATURE` from 73 to 22.5.

The driver now reads the project scale with `C4:GetTemperatureScale()` and reports
it on connect, and implements `SET_SCALE` so an installer can override it for a
single thermostat. The override is persisted and wins over the project scale, so a
reconnect does not stomp it (verified). `can_change_scale` is now True: ESPHome is
always Celsius internally, so the scale is purely what Control4 displays and the
driver can always change it.

Note the `SCALE` param carried on `TEMPERATURE_CHANGED` and the setpoint notifies
is a different thing - it declares the unit of the value being sent - and is
unchanged.

## #101 - no way to see whether a device is online

Two parts.

**A real bug.** `thermostatV2` has **no `ONLINE_CHANGED`** - the string is absent
from `/control4/drivers/thermostatV2.c4l` - so the notification the climate driver
was sending was a silent no-op and a thermostat stayed shown as connected forever
after its device dropped. It reports reachability through `CONNECTION { CONNECTED }`,
which drives proxy variable 1112 `IS_CONNECTED`. Fixed, and paired with the
`has_connection_status` capability.

Verified end to end: killed the climate mock, `IS_CONNECTED` now goes to 0.

`light_v2` and `fan` do implement `ONLINE_CHANGED` and already worked (confirmed a
light goes offline correctly). The `lock` proxy implements neither; its only
offline-ish signal is `LOCK_STATUS = IS_FAULT`, so that one is left alone and the
docs say so.

**A documentation gap.** Every driver has published a `Connected` BOOL variable
since v20260802, which is exactly what the reporter wanted, but it appeared in no
documentation anywhere. Now documented in the main driver's Driver Variables table
and in a Programming Variables section on each sub-driver.

## #102 - light_v2 color rate exception and greyed dimming

**Color rate exception.** The color rate bounds and defaults now ride every
`DYNAMIC_CAPABILITIES_CHANGED` instead of only when the light has color, so there
is no window in which a consumer sees a color rate control with no range - the
shape of the `defaultColorRate ... value 0.750 not between 0.000 and 0.000`
exception. Confirmed by hand that the light properties dialog now opens in
Composer without throwing.

**Greyed dimming.** Composer's test panel gates its dimming controls on the static
driver.xml capability **AND** the dynamic one, so the conservative baseline in
0141b2c left an installer unable to test dimming on a light that really is
dimmable. Measured on a CORE 1 by deploying two builds differing only in the
static values and binding each to the same ESPHome entities:

```
static  dynamic   GET_SETUP   Composer properties   Composer test panel
False   true      True        enabled               greyed
False   false     False       greyed                greyed
True    true      True        enabled               enabled
True    false     False       greyed                greyed
```

Composer's properties tab and Navigator both follow the dynamic value alone; only
the test panel ANDs the two. So a static True costs nothing on a light that is not
dimmable - it reports a dynamic `dimmer=false` and is correctly greyed everywhere,
and slider-less in the app - and it restores the test panel on one that is. The
app slider was confirmed working throughout, so this was never customer-facing.

The dimming tier therefore moves to True: `dimmer`, `set_level`, `ramp_level`,
`supports_target`, `supports_brightness_stop`. The color tier stays False - a full
colour light with `supports_color` and `supports_color_correlated_temperature`
declared False came up with its colour picker and colour temperature control
usable, so the AND does not apply there.

Leaving the colour tier alone also limits the blast radius of DRV-113, the
consumer-side bug where a static value chained with `or` cannot be told apart from
an undeclared one. Home Connect reads `dimmer`, `set_level`, `ramp_level`,
`supports_color` and `supports_color_correlated_temperature` that way; it does not
read `supports_target` or `supports_brightness_stop`, so those two are free.

Two corrections to earlier reasoning in this PR's history, recorded because both
were asserted in code comments and are wrong:

- There is no `color_rate_default` / `brightness_rate_default` capability in the
  proxy. A fresh install declaring `<color_rate_default>0</color_rate_default>`
  still seeds `c4type::Light Color::rateDefault = 750` in `state.db`. The entries
  are kept because Composer reads the static capability list directly, but the
  proxy ignores them.
- A capability omitted from `DYNAMIC_CAPABILITIES_CHANGED` is not forced to 0;
  `color_rate_max` stayed at 65535 for a light that sent no color capabilities.

Also tested and **not** reproduced: the documented note that setting `dimmer=true`
makes the proxy re-read `ramp_level` from the c4i and clobber a `ramp_level=true`
sent in the same notify. One atomic notify reaches the correct state, and sending
`dimmer=true` alone raises only `dimmer`, so a split send gains nothing.

## #103 - not addressed here

The reporter's premise does not hold: an ESPHome `button` entity's `BUTTON_LINK`
is created as an **Output**, not an Input, which is the correct load-side role
(compare `combo_dimmer.c4i`, where a load's button links are `consumer=False`,
against `control4_keypad_kpz-31-w.c4i`, where a keypad's buttons are
`consumer=True`). The underlying request - a physical paddle on the device driving
Control4 loads directly - is a genuine gap, but it depends on which entity type
their paddle actually is. Awaiting their YAML.

`test/dummy_buttons.yaml` lands here as groundwork: a 3-gang switch mock covering
`switch`, `binary_sensor`, `event`, `button` and a status-LED `light`, which is
what established the binding directions above.

## Test plan

- [x] `make test` - 311 assertions, 0 failures
- [x] Merged into `refs/pull/99/head`: climate harness 135 passed, 0 failed (0/44 without the shim stub)
- [x] `make check` - formatting clean
- [x] `make build` - full build including docs and README regeneration
- [x] Thermostat scale follows the project setting on connect (live)
- [x] `SET_SCALE` override persists and survives a reconnect (live)
- [x] Thermostat `IS_CONNECTED` drops to 0 when the ESPHome device goes away (live)
- [x] Light properties dialog opens in Composer without the color rate exception
- [x] Dynamic capabilities override static in both directions (live, both XML variants)
- [x] Full static/dynamic matrix checked in Composer across four devices
- [x] Composer test panel dimming live on a dimmable light, greyed on an on/off one
- [x] Colour picker and CCT usable with the colour tier left False
- [x] Brightness slider works in the Control4 app throughout
- [x] Binary light still reports `dimmer=False` in `GET_SETUP` with static True
- [x] RGBCT light reports colour, CCT and a 2700-6500K range from device discovery
