### PR TITLE
fix(bluetooth): restart the BLE scanner instead of rebooting the device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,13 +37,15 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 - Fixed Composer's test panel greying out the dimming controls for ESPHome
   lights that do support brightness. Dimming from the Control4 app was never
   affected.
-- Fixed Bluetooth proxy scanner recovery rebooting the device, which it did by
-  pressing whichever button had "restart" in its name. On some devices that is a
-  factory reset button. Recovery now restarts the scanner itself, which is
-  quicker, keeps existing Bluetooth connections alive, and never presses
-  anything. (DRV-115)
-- Fixed Bluetooth proxies never watching for a stuck scanner unless the device
-  exposed a restart button. Scanner recovery now runs on every Bluetooth proxy.
+- Fixed Bluetooth proxy scanner recovery never running on many devices. It
+  needed a button with "restart" in its name, so proxies whose restart button is
+  named in another language, or that expose no such button, silently had no
+  recovery at all. Recovery no longer needs a button and runs on any proxy that
+  reports its scanner state.
+- Fixed Bluetooth proxy scanner recovery rebooting the device, and choosing what
+  to press by name, which could press an unrelated button. It now restarts the
+  scanner itself, which is quicker and keeps existing Bluetooth connections
+  alive. (DRV-115)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 - Fixed Composer's test panel greying out the dimming controls for ESPHome
   lights that do support brightness. Dimming from the Control4 app was never
   affected.
+- Fixed Bluetooth proxy scanner recovery rebooting the device, which it did by
+  pressing whichever button had "restart" in its name. On some devices that is a
+  factory reset button. Recovery now restarts the scanner itself, which is
+  quicker, keeps existing Bluetooth connections alive, and never presses
+  anything. (DRV-115)
+- Fixed Bluetooth proxies never watching for a stuck scanner unless the device
+  exposed a restart button. Scanner recovery now runs on every Bluetooth proxy.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -928,6 +928,15 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 - Fixed Composer's test panel greying out the dimming controls for ESPHome
   lights that do support brightness. Dimming from the Control4 app was never
   affected.
+- Fixed Bluetooth proxy scanner recovery never running on many devices. It
+  needed a button with "restart" in its name, so proxies whose restart button is
+  named in another language, or that expose no such button, silently had no
+  recovery at all. Recovery no longer needs a button and runs on any proxy that
+  reports its scanner state.
+- Fixed Bluetooth proxy scanner recovery rebooting the device, and choosing what
+  to press by name, which could press an unrelated button. It now restarts the
+  scanner itself, which is quicker and keeps existing Bluetooth connections
+  alive. (DRV-115)
 
 ### Changed
 

--- a/drivers/esphome/driver.lua
+++ b/drivers/esphome/driver.lua
@@ -592,15 +592,6 @@ function RefreshStatus()
           else
             log:debug("No Entities['%s']:discovered() handler", entity.entity_type)
           end
-
-          -- Detect restart button for scanner recovery
-          if entity.entity_type == "button" then
-            local buttonName = entity.name or ""
-            if buttonName:lower():find("restart") then
-              log:info("Found restart button entity: %s", ESPHomeClient.describeEntity(entity))
-              bluetoothProxyCapability:setRestartButtonKey(entity.key)
-            end
-          end
         end
 
         return entities

--- a/src/esphome/capabilities/bluetooth_proxy.lua
+++ b/src/esphome/capabilities/bluetooth_proxy.lua
@@ -190,6 +190,14 @@ function BluetoothProxyCapability:_startScannerWatchdog()
     return
   end
 
+  -- The watchdog reads scanner state to tell a stalled scanner from one that
+  -- is legitimately stopped. Without that flag the cached state never leaves
+  -- its default and every check would be a no-op.
+  if bit32.band(self._featureFlags, FEATURE_FLAGS.SCANNER_STATE) == 0 then
+    log:debug("Scanner watchdog not started: device does not report scanner state")
+    return
+  end
+
   log:debug("Starting scanner watchdog (interval: %ds)", SCANNER_WATCHDOG_TIMEOUT_SECONDS)
   self._scannerWatchdogActive = true
   self._scannerWatchdogSeen = false

--- a/src/esphome/capabilities/bluetooth_proxy.lua
+++ b/src/esphome/capabilities/bluetooth_proxy.lua
@@ -30,6 +30,18 @@ local SCANNER_WATCHDOG_TIMEOUT_SECONDS = 90
 --- Timer key for the scanner watchdog
 local SCANNER_WATCHDOG_TIMER_KEY = "BLEScannerWatchdog"
 
+--- How many times to restart the scanner in place before leaving it to
+--- ESPHome's own recovery. Each attempt costs one watchdog interval.
+local SCANNER_RECOVERY_RESTART_ATTEMPTS = 2
+
+--- Timer key for restoring the scanner mode after an in-place restart.
+local SCANNER_RECOVERY_RESTORE_TIMER_KEY = "BLEScannerRecoveryRestore"
+
+--- How long to leave the scanner in the opposite mode before restoring it.
+--- Long enough for the firmware to finish stopping and relaunch the scan, so
+--- restoring does not land while the scanner is still STOPPING.
+local SCANNER_RECOVERY_RESTORE_SECONDS = 5
+
 --- Reverse lookup for BluetoothScannerState enum (value -> display name)
 --- States that involve active scanning will have mode appended (e.g., "Scanning (Passive)")
 --- @type table<ProtoBluetoothScannerState, string?>
@@ -69,7 +81,6 @@ local SCANNER_MODE_NAMES = {
 --- @field _scannerWatchdogActive boolean Whether the scanner watchdog is active
 --- @field _scannerWatchdogSeen boolean Whether any advertisements were received since last watchdog check
 --- @field _scannerRecoveryAttempts integer Number of recovery attempts since last successful scan
---- @field _restartButtonKey number|nil The key of the restart button entity (nil if not found)
 local BluetoothProxyCapability = {
   TYPE = "bluetooth_proxy",
   LABEL_PROPERTY_NAME = "Bluetooth Proxy Settings",
@@ -141,7 +152,6 @@ function BluetoothProxyCapability:new(client)
   instance._scannerWatchdogActive = false
   instance._scannerWatchdogSeen = false
   instance._scannerRecoveryAttempts = 0
-  instance._restartButtonKey = nil
   return instance
 end
 
@@ -174,16 +184,9 @@ function BluetoothProxyCapability:_onAdvertisementReceived()
 end
 
 --- Start the scanner watchdog.
---- Only starts if a restart button is available for recovery.
 --- @private
 function BluetoothProxyCapability:_startScannerWatchdog()
   if self._scannerWatchdogActive then
-    return
-  end
-
-  -- Only enable watchdog if we have a restart button for recovery
-  if not self._restartButtonKey then
-    log:debug("Scanner watchdog not started: no restart button available for recovery")
     return
   end
 
@@ -198,14 +201,6 @@ function BluetoothProxyCapability:_startScannerWatchdog()
   end, true) -- recurring
 end
 
---- Set the restart button entity key for scanner recovery.
---- Called by the driver when a restart button entity is discovered.
---- @param key number The button entity key
-function BluetoothProxyCapability:setRestartButtonKey(key)
-  log:debug("Restart button key set: %s", key)
-  self._restartButtonKey = key
-end
-
 --- Stop the scanner watchdog.
 --- @private
 function BluetoothProxyCapability:_stopScannerWatchdog()
@@ -217,6 +212,32 @@ function BluetoothProxyCapability:_stopScannerWatchdog()
   self._scannerWatchdogActive = false
   self._scannerWatchdogSeen = false
   CancelTimer(SCANNER_WATCHDOG_TIMER_KEY)
+  CancelTimer(SCANNER_RECOVERY_RESTORE_TIMER_KEY)
+end
+
+--- Restart the BLE scanner in place, without rebooting the device.
+---
+--- ESPHome ignores a set-mode request for the mode the scanner is already in,
+--- so the round trip through the opposite mode is what makes it act: each
+--- accepted change stops the scan and re-arms continuous scanning, which the
+--- firmware relaunches once the stack is idle. The mode is restored afterwards
+--- because active scanning is what BTHome devices need.
+--- @private
+--- @return Deferred<nil, string> result Resolves once the opposite mode is set.
+function BluetoothProxyCapability:_restartScanner()
+  local scannerState = self._client:getBluetoothScannerState()
+  local wasActive = scannerState.mode ~= ESPHomeProtoSchema.Enum.BluetoothScannerMode.BLUETOOTH_SCANNER_MODE_PASSIVE
+
+  return self._client:setBluetoothScannerMode(not wasActive):next(function()
+    SetTimer(SCANNER_RECOVERY_RESTORE_TIMER_KEY, SCANNER_RECOVERY_RESTORE_SECONDS * ONE_SECOND, function()
+      self._client:setBluetoothScannerMode(wasActive):next(function()
+        log:debug("Scanner recovery: scanner mode restored")
+      end, function(err)
+        -- The next connect re-applies the mode, so this is not fatal.
+        log:error("Scanner recovery: failed to restore scanner mode: %s", err)
+      end)
+    end)
+  end)
 end
 
 --- Called when the scanner watchdog timer fires.
@@ -244,31 +265,25 @@ function BluetoothProxyCapability:_onScannerWatchdogFired()
     return
   end
 
-  -- Safety check - should not happen since watchdog only starts if we have restart button
-  if not self._restartButtonKey then
-    log:warn("Scanner watchdog fired but no restart button available, stopping watchdog")
-    self:_stopScannerWatchdog()
+  self._scannerRecoveryAttempts = self._scannerRecoveryAttempts + 1
+
+  if self._scannerRecoveryAttempts <= SCANNER_RECOVERY_RESTART_ATTEMPTS then
+    log:warn(
+      "Scanner watchdog: No BLE advertisements received for %ds (attempt %d), restarting the scanner",
+      SCANNER_WATCHDOG_TIMEOUT_SECONDS,
+      self._scannerRecoveryAttempts
+    )
+    self:_restartScanner():next(nil, function(err)
+      log:error("Scanner recovery: failed to restart the scanner: %s", err)
+    end)
     return
   end
 
-  self._scannerRecoveryAttempts = self._scannerRecoveryAttempts + 1
-  log:warn(
-    "Scanner watchdog: No BLE advertisements received for %ds (attempt %d), rebooting device to recover",
-    SCANNER_WATCHDOG_TIMEOUT_SECONDS,
-    self._scannerRecoveryAttempts
-  )
-
-  -- Stop watchdog - device will reboot and we'll reinitialize on reconnect
-  self:_stopScannerWatchdog()
-
-  -- Attempt recovery by pressing the restart button
-  self._client:pressButton(self._restartButtonKey):next(function()
-    log:info("Scanner recovery: restart button pressed, device will reboot")
-  end, function(err)
-    log:error("Scanner recovery: failed to press restart button: %s", err)
-    -- Restart the watchdog to try again later
-    self:_startScannerWatchdog()
-  end)
+  -- Nothing further to try from here. ESPHome reboots itself for the scanner
+  -- failures it can detect, so keep watching rather than giving up.
+  if self._scannerRecoveryAttempts == SCANNER_RECOVERY_RESTART_ATTEMPTS + 1 then
+    log:warn("Scanner watchdog: Scanner did not recover after %d restarts", SCANNER_RECOVERY_RESTART_ATTEMPTS)
+  end
 end
 
 --- Update the read-only status property.

--- a/test/test_scanner_recovery.lua
+++ b/test/test_scanner_recovery.lua
@@ -1,0 +1,152 @@
+-- Tests for BLE scanner recovery escalation in
+-- src/esphome/capabilities/bluetooth_proxy.lua.
+--
+-- Run from the repo root:
+--   LUA_PATH="$PWD/test/?.lua;$PWD/src/?.lua;$PWD/vendor/?.lua;$PWD/vendor/?/init.lua;;" \
+--     luajit -e "require('c4_shim')" test/test_scanner_recovery.lua
+
+local pass, fail = 0, 0
+local function check(name, ok, detail)
+  if ok then
+    pass = pass + 1
+    print(string.format("  ok   %s", name))
+  else
+    fail = fail + 1
+    print(string.format("  FAIL %s%s", name, detail and ("  -> " .. tostring(detail)) or ""))
+  end
+end
+
+require("c4_shim")
+require("lib.utils")
+require("drivers-common-public.global.lib")
+require("drivers-common-public.global.timer")
+
+local deferred = require("deferred")
+local BluetoothProxyCapability = require("esphome.capabilities.bluetooth_proxy")
+local ESPHomeProtoSchema = require("esphome.proto_schema")
+
+local ScannerState = ESPHomeProtoSchema.Enum.BluetoothScannerState
+local ScannerMode = ESPHomeProtoSchema.Enum.BluetoothScannerMode
+
+--- A client stub recording the recovery calls the capability makes.
+--- @return table client
+local function fakeClient()
+  local client = {
+    calls = {},
+    scannerState = {
+      state = ScannerState.BLUETOOTH_SCANNER_STATE_RUNNING,
+      mode = ScannerMode.BLUETOOTH_SCANNER_MODE_ACTIVE,
+      initialized = true,
+    },
+  }
+
+  function client:getBluetoothScannerState()
+    return self.scannerState
+  end
+
+  function client:setBluetoothScannerMode(active)
+    table.insert(self.calls, active and "mode:active" or "mode:passive")
+    local d = deferred.new()
+    d:resolve()
+    return d
+  end
+
+  return client
+end
+
+--- Build a capability wired to a stub client, with the watchdog already armed.
+--- @return table capability, table client
+local function capabilityWithWatchdog()
+  local client = fakeClient()
+  local capability = BluetoothProxyCapability:new(client)
+  capability._scannerWatchdogActive = true
+  return capability, client
+end
+
+--------------------------------------------------------------------------------
+print("\n[1] a healthy scanner is left alone")
+--------------------------------------------------------------------------------
+do
+  local capability, client = capabilityWithWatchdog()
+  capability._scannerWatchdogSeen = true
+  capability:_onScannerWatchdogFired()
+
+  check("no recovery attempted", #client.calls == 0, table.concat(client.calls, ","))
+  check("seen flag reset for the next interval", capability._scannerWatchdogSeen == false)
+end
+
+--------------------------------------------------------------------------------
+print("\n[2] a stalled scanner is restarted in place")
+--------------------------------------------------------------------------------
+do
+  local capability, client = capabilityWithWatchdog()
+  capability:_onScannerWatchdogFired()
+
+  -- ESPHome ignores a set-mode request for the mode it is already in, so
+  -- recovery has to leave the current mode to make the firmware act.
+  check("scanner mode flipped away from active", client.calls[1] == "mode:passive", table.concat(client.calls, ","))
+  check("nothing else is touched", client.calls[2] == nil, table.concat(client.calls, ","))
+  check("watchdog still running", capability._scannerWatchdogActive == true)
+end
+
+--------------------------------------------------------------------------------
+print("\n[3] recovery is bounded and never reboots the device")
+--------------------------------------------------------------------------------
+do
+  local capability, client = capabilityWithWatchdog()
+
+  capability:_onScannerWatchdogFired()
+  capability:_onScannerWatchdogFired()
+  check("two in-place restarts attempted", #client.calls == 2, table.concat(client.calls, ","))
+
+  -- Past the budget the driver stops acting. ESPHome reboots itself for the
+  -- scanner failures it can detect, so there is nothing left to escalate to.
+  capability:_onScannerWatchdogFired()
+  capability:_onScannerWatchdogFired()
+  check("no further action past the budget", #client.calls == 2, table.concat(client.calls, ","))
+  check("watchdog keeps watching", capability._scannerWatchdogActive == true)
+  check("only scanner mode is ever touched", not table.concat(client.calls, ","):find("press"))
+end
+
+--------------------------------------------------------------------------------
+print("\n[4] a scanner that is not running is not recovered")
+--------------------------------------------------------------------------------
+do
+  local capability, client = capabilityWithWatchdog()
+  client.scannerState.state = ScannerState.BLUETOOTH_SCANNER_STATE_STOPPED
+  capability:_onScannerWatchdogFired()
+
+  check("no recovery for a stopped scanner", #client.calls == 0, table.concat(client.calls, ","))
+  check("attempt counter untouched", capability._scannerRecoveryAttempts == 0)
+end
+
+--------------------------------------------------------------------------------
+print("\n[5] returning advertisements reset the escalation")
+--------------------------------------------------------------------------------
+do
+  local capability, client = capabilityWithWatchdog()
+  capability:_onScannerWatchdogFired()
+  check("one attempt recorded", capability._scannerRecoveryAttempts == 1)
+
+  capability._scannerWatchdogSeen = true
+  capability:_onScannerWatchdogFired()
+  check("counter cleared once ads resume", capability._scannerRecoveryAttempts == 0)
+
+  -- A later stall starts the ladder over rather than jumping to a reboot.
+  capability:_onScannerWatchdogFired()
+  check("next stall restarts in place again", client.calls[2] == "mode:passive", table.concat(client.calls, ","))
+end
+
+--------------------------------------------------------------------------------
+print("\n[6] a passive scanner is flipped the other way")
+--------------------------------------------------------------------------------
+do
+  local capability, client = capabilityWithWatchdog()
+  client.scannerState.mode = ScannerMode.BLUETOOTH_SCANNER_MODE_PASSIVE
+  capability:_onScannerWatchdogFired()
+
+  check("flipped to active from passive", client.calls[1] == "mode:active", table.concat(client.calls, ","))
+end
+
+print(string.format("\n%d passed, %d failed\n", pass, fail))
+os.exit(fail == 0 and 0 or 1)

--- a/test/test_scanner_recovery.lua
+++ b/test/test_scanner_recovery.lua
@@ -54,11 +54,15 @@ local function fakeClient()
   return client
 end
 
+--- Bluetooth proxy feature flag for scanner state reporting.
+local SCANNER_STATE_FLAG = 0x40
+
 --- Build a capability wired to a stub client, with the watchdog already armed.
 --- @return table capability, table client
 local function capabilityWithWatchdog()
   local client = fakeClient()
   local capability = BluetoothProxyCapability:new(client)
+  capability._featureFlags = SCANNER_STATE_FLAG
   capability._scannerWatchdogActive = true
   return capability, client
 end
@@ -85,7 +89,13 @@ do
   -- ESPHome ignores a set-mode request for the mode it is already in, so
   -- recovery has to leave the current mode to make the firmware act.
   check("scanner mode flipped away from active", client.calls[1] == "mode:passive", table.concat(client.calls, ","))
-  check("nothing else is touched", client.calls[2] == nil, table.concat(client.calls, ","))
+  check("nothing else is touched yet", client.calls[2] == nil, table.concat(client.calls, ","))
+
+  -- The restore runs on a timer. A silently dead restore would strand the
+  -- proxy in passive mode, which is what BTHome devices cannot work with.
+  ShimFireTimers()
+  check("mode restored after the restart", client.calls[2] == "mode:active", table.concat(client.calls, ","))
+  check("nothing further", client.calls[3] == nil, table.concat(client.calls, ","))
   check("watchdog still running", capability._scannerWatchdogActive == true)
 end
 
@@ -96,14 +106,17 @@ do
   local capability, client = capabilityWithWatchdog()
 
   capability:_onScannerWatchdogFired()
+  ShimFireTimers()
   capability:_onScannerWatchdogFired()
-  check("two in-place restarts attempted", #client.calls == 2, table.concat(client.calls, ","))
+  ShimFireTimers()
+  check("two restarts, each restored", #client.calls == 4, table.concat(client.calls, ","))
 
   -- Past the budget the driver stops acting. ESPHome reboots itself for the
   -- scanner failures it can detect, so there is nothing left to escalate to.
   capability:_onScannerWatchdogFired()
   capability:_onScannerWatchdogFired()
-  check("no further action past the budget", #client.calls == 2, table.concat(client.calls, ","))
+  ShimFireTimers()
+  check("no further action past the budget", #client.calls == 4, table.concat(client.calls, ","))
   check("watchdog keeps watching", capability._scannerWatchdogActive == true)
   check("only scanner mode is ever touched", not table.concat(client.calls, ","):find("press"))
 end
@@ -146,6 +159,22 @@ do
   capability:_onScannerWatchdogFired()
 
   check("flipped to active from passive", client.calls[1] == "mode:active", table.concat(client.calls, ","))
+end
+
+--------------------------------------------------------------------------------
+print("\n[7] the watchdog only starts where scanner state is reported")
+--------------------------------------------------------------------------------
+do
+  -- Without the SCANNER_STATE flag the cached state never leaves its default,
+  -- so the watchdog could only ever take its ignore branch.
+  local capability = BluetoothProxyCapability:new(fakeClient())
+  capability._featureFlags = 0x01 -- passive scan only
+  capability:_startScannerWatchdog()
+  check("not started without scanner state support", capability._scannerWatchdogActive == false)
+
+  capability._featureFlags = 0x01 + SCANNER_STATE_FLAG
+  capability:_startScannerWatchdog()
+  check("started once scanner state is reported", capability._scannerWatchdogActive == true)
 end
 
 print(string.format("\n%d passed, %d failed\n", pass, fail))


### PR DESCRIPTION
## Summary

BLE scanner recovery pressed a button it found by matching `"restart"` against the entity name. It now restarts the scanner itself over the API and presses nothing.

The original goal was to fix that name match. Investigating ESPHome's source turned up a better mechanism, so the detection code this started as is deleted rather than repaired.

## Why the name match could not just be tightened

ESPHome puts no platform information on the wire. `ListEntitiesButtonResponse` carries only `object_id`, `key`, `name`, `icon`, `disabled_by_default`, `entity_category`, `device_class` and `device_id`.

`device_class: restart` is not specific to the node restart button. In 2026.7.2 it is also declared by `factory_reset`, `safe_mode`, and the restart/reset buttons of `ld2410`, `ld2412`, `ld2420`, `ld2450`, `seeed_mr24hpc1` and `seeed_mr60fda2`. Read back off the test proxy:

```
Restart          device_class=restart  entity_category=1  icon=mdi:restart
Safe Mode Boot   device_class=restart  entity_category=1  icon=mdi:restart-alert
Factory Reset    device_class=restart  entity_category=1  icon=mdi:restart-alert
```

That is a stock `generic-bluetooth-proxy`. Same class, same category — only the icon differs, and a user can override it. Adding icon and category still leaves `ld2420`'s `revert_config`, which declares `device_class=restart`, `entity_category=config` and `icon=mdi:restart` and is indistinguishable from a real restart button. Only the name separates those two, and requiring the name to contain `"restart"` excludes every localized button (Neustart, Redémarrer, Riavvia, Reiniciar) — the original bug.

Guessing wrong is unattended and clears WiFi credentials, needing physical reflashing.

## What it does instead

`BluetoothScannerSetModeRequest`, already wired up in the client. ESPHome ignores a set-mode request for the mode the scanner is already in, so the round trip through the opposite mode is what makes it act — each accepted change stops the scan and re-arms continuous scanning, which the firmware relaunches once the stack is idle:

```cpp
void BluetoothProxy::bluetooth_scanner_set_mode(bool active) {
  if (this->parent_->get_scan_active() == active) return;
  this->parent_->set_scan_active(active);
  this->parent_->stop_scan();
  this->parent_->set_scan_continuous(true);
}
```

The mode is restored afterwards because active scanning is what BTHome devices need. No entity required, nothing pressed, and existing Bluetooth connections survive.

Recovery makes two attempts and then leaves the scanner alone. ESPHome already reboots itself for the failures it can detect: 255 failed scan starts (`handle_scanner_failure_`), or a scan that never terminates within twice the scan duration.

## Also fixed

`_startScannerWatchdog` returned early when no restart button was found, so proxies without one had no scanner monitoring at all. Since the button was found by name, that included every proxy whose restart button is named in another language. It now starts on any proxy that reports scanner state.

It is gated on the `SCANNER_STATE` (`0x40`) feature flag, which was declared but never read. Without it the cached scanner state never leaves its `IDLE`/uninitialized default, so the watchdog could only ever take its ignore branch.

## Test plan

- [x] `make test` — 326 assertions, 15 new covering the escalation ladder, including one asserting nothing but scanner mode is ever touched
- [x] `make check`, `make build-nodocs`
- [x] `make build` (not just `build-nodocs`, which skips the `README.md` generation the dirty-tree check needs)
- [x] Real ESP32 proxy on ESPHome 2026.7.2: two in-place restarts, each a clean `RUNNING → STOPPING → IDLE → STARTING → RUNNING` cycle with the mode restored, advertisements flowing throughout, device left in `RUNNING (ACTIVE)`
- [x] Past the budget: one warning, watchdog keeps watching, nothing pressed

**What the hardware run does not establish:** it exercises the mechanism against a *healthy* scanner, which is not the state the code runs in. That the set-mode round trip drives the state machine is proven; that it recovers a *wedged* scanner is not, and would need a reproduction of the wedge. Those come apart if the stall is in the ESP-IDF stack rather than in ESPHome's own state.

DRV-115 (To be discussed) tracks the remaining gap. Framed precisely: a scanner that cycles normally but returns no advertisements never fails a scan start and never exceeds the scan timeout, so neither ESPHome reboot path fires. That is the exact state this watchdog exists to detect, and after two in-place restarts nothing else happens. The ticket is about whether that is acceptable, not about restoring something ESPHome already covers.
