### PR TITLE
fix: tell sub-drivers when the ESPHome device goes away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,9 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 - Fixed Composer's test panel greying out the dimming controls for ESPHome
   lights that do support brightness. Dimming from the Control4 app was never
   affected.
-- Fixed lights, thermostats, fans and locks still showing as connected after the
-  ESPHome driver's IP address, port or credentials were changed. They now go
-  offline with the device until it reconnects.
+- Fixed lights, thermostats, water heaters, fans and locks still showing as
+  connected after the ESPHome driver's IP address, port or credentials were
+  changed or cleared. They now go offline with the device until it reconnects.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 - Fixed Composer's test panel greying out the dimming controls for ESPHome
   lights that do support brightness. Dimming from the Control4 app was never
   affected.
+- Fixed lights, thermostats, fans and locks still showing as connected after the
+  ESPHome driver's IP address, port or credentials were changed. They now go
+  offline with the device until it reconnects.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -928,6 +928,9 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 - Fixed Composer's test panel greying out the dimming controls for ESPHome
   lights that do support brightness. Dimming from the Control4 app was never
   affected.
+- Fixed lights, thermostats, fans and locks still showing as connected after the
+  ESPHome driver's IP address, port or credentials were changed. They now go
+  offline with the device until it reconnects.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -928,9 +928,9 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 - Fixed Composer's test panel greying out the dimming controls for ESPHome
   lights that do support brightness. Dimming from the Control4 app was never
   affected.
-- Fixed lights, thermostats, fans and locks still showing as connected after the
-  ESPHome driver's IP address, port or credentials were changed. They now go
-  offline with the device until it reconnects.
+- Fixed lights, thermostats, water heaters, fans and locks still showing as
+  connected after the ESPHome driver's IP address, port or credentials were
+  changed or cleared. They now go offline with the device until it reconnects.
 
 ### Changed
 

--- a/drivers/esphome/driver.lua
+++ b/drivers/esphome/driver.lua
@@ -421,6 +421,12 @@ end
 --- Backoff period in seconds after a fatal connection error before retrying.
 local FATAL_ERROR_BACKOFF = 120
 
+--- Whether the last heartbeat saw a live connection. Deliberately outside
+--- Connect(), because changing IP, port or credentials re-runs it: a copy scoped
+--- there would reset to false and the next heartbeat would see no transition, so
+--- sub-drivers would never be told the device went away.
+local wasConnected = false
+
 function Connect()
   log:trace("Connect()")
   if not gInitialized then
@@ -438,7 +444,6 @@ function Connect()
 
   local lastUpdateTime = os.time() -- Don't check for updates on the first cycle
   local lastFatalErrorTime = 0 -- Track when the last fatal error occurred
-  local wasConnected = false -- Track connection state transitions
 
   local function notifyEntitiesDisconnected()
     for _, handler in pairs(Entities) do

--- a/drivers/esphome/driver.lua
+++ b/drivers/esphome/driver.lua
@@ -456,17 +456,29 @@ function Connect()
     end
   end
 
+  --- Drop the connection and tell sub-drivers straight away. The guards below
+  --- return before the heartbeat's transition check, and one of them also stops
+  --- the heartbeat, so there is no later cycle to notice the drop.
+  local function disconnectAndNotify()
+    esphome:disconnect()
+    if wasConnected then
+      log:info("Connection closed, notifying sub-drivers")
+      notifyEntitiesDisconnected()
+      wasConnected = false
+    end
+  end
+
   local heartbeat = function()
     --#ifdef DRIVERCENTRAL
     if DC_X == 0 then
       updateStatus("No active license", false)
-      esphome:disconnect()
+      disconnectAndNotify()
       return
     end
     --#endif
     if not esphome:isConfigured() then
       updateStatus("Not configured", false)
-      esphome:disconnect()
+      disconnectAndNotify()
       CancelTimer("heartbeat")
       return
     end

--- a/src/esphome/entities/water_heater.lua
+++ b/src/esphome/entities/water_heater.lua
@@ -158,4 +158,15 @@ function WaterHeaterEntity:updated(entity, state, messageSchema)
   end
 end
 
+--- Notify sub-drivers that the ESPHome device has disconnected.
+--- Water heaters share the ESPHome Climate sub-driver but bind under their own
+--- entity type, so ClimateEntity:disconnected() does not reach them.
+--- @return void
+function WaterHeaterEntity:disconnected()
+  log:trace("WaterHeaterEntity:disconnected()")
+  for _, binding in pairs(bindings:getDynamicBindings(self.TYPE)) do
+    SendToProxy(binding.bindingId, "UPDATE_DISCONNECT", {}, "NOTIFY")
+  end
+end
+
 return WaterHeaterEntity


### PR DESCRIPTION
Two paths left a sub-driver reporting connected against a device that was not there. Found while putting a thermostat into a disconnected state to look at Navigator, so both are reproduced rather than inferred.

## 1. Changing a connection setting reset the transition state

`wasConnected` lived inside `Connect()`, which `OPC.IP_Address`, `OPC.Port`, `OPC.Password`, `OPC.Encryption_Key` and `OPC.Use_OpenSSL` all call. Each call built a fresh closure with `wasConnected = false` plus a new heartbeat timer, so the heartbeat that followed saw no true to false edge and `notifyEntitiesDisconnected()` never ran.

The heartbeat guards on the transition:

```lua
local connected = esphome:isConnected()
if wasConnected and not connected then
  log:info("Connection lost, notifying sub-drivers")
  notifyEntitiesDisconnected()
end
wasConnected = connected
```

Measured on a CORE 1 with a host-mode climate mock. Repointing the parent at an unreachable address:

```
before   parent Connected=0, driver status=Connection failed: Connection refused
         climate sub-driver status=Connected, proxy IS_CONNECTED=1
```

It stayed that way for over three minutes while the parent logged `Connection refused` every ten seconds, and no `Connection lost, notifying sub-drivers` line ever appeared. I had to send `UPDATE_DISCONNECT` by hand to clear it.

After hoisting `wasConnected` to file scope, the identical repro:

```
18:02:14 [INFO ]: Connection lost, notifying sub-drivers
18:02:14 [DEBUG]: Connecting to ESPHome device at <unreachable>
after     parent=0  driver=Disconnected  Connected=0  IS_CONNECTED=0
```

No manual intervention.

## 2. Water heaters were never told at all

`WaterHeaterEntity.TYPE` is `WATER_HEATER`, but they share the ESPHome Climate sub-driver, and `ClimateEntity:disconnected()` only walks the `CLIMATE` namespace:

```lua
for _, binding in pairs(bindings:getDynamicBindings(self.TYPE)) do
```

So no path reached a water heater, including an ordinary device drop. Added `WaterHeaterEntity:disconnected()`.

Checked the other entity types while I was there. Of the five with proxy sub-drivers, `climate`, `fan`, `light` and `lock` already implement `disconnected()`; `water_heater` was the only gap. The rest (`binary_sensor`, `switch`, `cover`, `sensor`, `number`, `select`, `text`, `text_sensor`, `date`, `time`, `datetime`, `event`, `button`) are variable, relay and contact backed rather than proxy sub-drivers, so they have no proxy connection state to go stale. Left alone.

## Changelog

The unreleased entry from #104 already reads "Fixed thermostats and water heaters staying shown as connected after the ESPHome device went offline." That was accurate about thermostats and not about water heaters, since the handler did not exist. It becomes true with this change, so it is left as-is rather than duplicated.

The connection setting bug is separate and pre-existing, so it gets its own entry. Before #104 it was masked on thermostats, because `ONLINE_CHANGED` is a no-op on `thermostatV2`, but lights, fans and locks have been affected all along.

## Test plan

- [x] `make test` 429 passed, 0 failed
- [x] `make check`, `make build`
- [x] Repointing a connected parent at an unreachable address now drives the sub-driver to Disconnected and `IS_CONNECTED` to 0, verified on a CORE 1 (fails without the change, on the same rig)
- [x] `Connection lost, notifying sub-drivers` appears in the parent log where it previously never did
- [ ] Water heater disconnect not exercised on hardware. There is no water heater entity on the test rig, so that half is by inspection: same binding walk as the climate handler, one namespace over