### PR TITLE
test: add a button entity to the inputs mock

### DIFF
--- a/test/dummy_inputs.yaml
+++ b/test/dummy_inputs.yaml
@@ -10,6 +10,7 @@
 #   .esphome/build/dummy-inputs/.pioenvs/dummy-inputs/program
 #
 # API services (callable from the Control4 driver or test scripts):
+#   - press_local_button()        presses the `button` entity from the device side
 #   - fire_button_press()         fires "press" on the test event
 #   - fire_button_double()        fires "double_press" on the test event
 #   - fire_button_long()          fires "long_press" on the test event
@@ -44,6 +45,9 @@ api:
         - event.trigger:
             id: test_event
             event_type: "long_press"
+    - service: press_local_button
+      then:
+        - button.press: test_button
     - service: device_set_mode
       variables:
         opt: string
@@ -96,6 +100,15 @@ select:
       - "Manual"
       - "Off"
       - "Eco"
+
+button:
+  # Stateless: the controller presses it and the device reports nothing back,
+  # so a local press is invisible over the API.
+  - platform: template
+    name: "Test Action Button"
+    id: test_button
+    on_press:
+      - lambda: 'ESP_LOGI("button", "test_button on_press fired ON DEVICE");'
 
 event:
   - platform: template


### PR DESCRIPTION
Adds a `button` entity to `test/dummy_inputs.yaml`. The mock covered `select`,
`event`, `date`, `time` and `datetime` but had no `button`, which is the one
entity type whose direction is easy to get wrong.

## Why it is worth having

An ESPHome `button` is an actuator. It is announced at discovery, the controller
presses it with `ButtonCommandRequest`, and nothing comes back. There is no
button state or event message in the protocol at all, so a press that happens on
the device is invisible to Control4.

That matters because it is a plausible thing to reach for. Pressing a `button`
entity from a device-side automation, for instance an LVGL touch widget doing
`on_click: - button.press: my_button`, runs `on_press` locally and Control4 never
hears about it. The config looks correct and does nothing. Came up in #103.

## Verified on hardware rather than read off the protocol

Driven against a CORE 1 with the driver bound to this mock. The device pressed
its own `button` and fired its own `event` on the same 10s cadence, so both paths
ran under identical conditions.

Device side, both genuinely happening:

```
[I][probe]:  PRESSING button entity locally
[I][button]: test_button on_press fired ON DEVICE
[I][probe]:  FIRING event entity locally
```

Driver side, only one arrives:

```
Received Event state update: {"event_type":"press","key":248732104}
Fired event press for event 'Test Button'
```

Over four cycles the driver received zero messages for the button. It appears
once, in the discovery payload, and is silent after. The `event` entity on the
same cadence delivered every press.

The other direction does work, which is the point of the entity:

```
Sending message ButtonCommandRequest with 5 byte(s) of data
Command press sent to button 'Test Action Button'
```

and the device logged `on_press fired ON DEVICE` with no local press marker
before it.

Also confirmed on the wire: the `button` entity creates its `BUTTON_LINK` as an
Output, and the `event` entity creates no binding.

## Notes

`press_local_button` reproduces the device-side press, so the silent case is
testable rather than theoretical.

No changelog entry: test fixture only, nothing user facing.

## Test plan

- [x] `esphome compile test/dummy_inputs.yaml`
- [x] Driver bound to the mock on a CORE 1, entity discovered, `BUTTON_LINK`
      created as Output
- [x] Device-side press produces no driver traffic, with the `event` entity as a
      control proving the connection was live
- [x] `DO_CLICK` from Control4 reaches the device
