### PR TITLE
feat: let event entities drive loads as keypad buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ## Unreleased
 
+### Added
+
+- Added a button connection for each event type an ESPHome event entity
+  declares, so a touch button or gesture on the device can drive a light, scene
+  or any other load directly, without Programming.
+
 ### Fixed
 
 - Fixed an automatic update sometimes leaving companion drivers on the previous

--- a/README.md
+++ b/README.md
@@ -487,15 +487,20 @@ the matching read-only Device Info properties.
 | Cover         | `CONTACT_SENSOR`                | Open/closed state contacts                                        |
 | Cover         | `RELAY`                         | Open/close/stop control relays                                    |
 | Button        | `BUTTON_LINK`                   | Allows other devices to trigger button                            |
+| Event         | `BUTTON_LINK`                   | One connection per event type, triggers other devices             |
 | Climate       | `ESPHOME_CLIMATE`               | Bind to ESPHome Climate sub-driver [\*\*](#climate-services-note) |
 | Fan           | `ESPHOME_FAN_N_SPEED[_REVERSE]` | Bind to ESPHome Fan sub-driver                                    |
 | Light         | `ESPHOME_LIGHT`                 | Bind to ESPHome Light sub-driver                                  |
 | Lock          | `ESPHOME_LOCK`                  | Bind to ESPHome Lock sub-driver                                   |
 | Water Heater  | `ESPHOME_CLIMATE`               | Bind to ESPHome Climate sub-driver                                |
 
-> **Note:** Sensor, Number, Select, Text, Text Sensor, Date, Time, Datetime, and
-> Event entities do not create bindings. They expose data only through variables
-> and events.
+> **Note:** Sensor, Number, Select, Text, Text Sensor, Date, Time and Datetime
+> entities do not create bindings. They expose data only through variables and
+> events.
+
+> **Note:** The Button and Event binding classes are the same but point opposite
+> ways. A Button binding lets another device press the ESPHome button; an Event
+> binding lets the ESPHome device act as a keypad button and drive a load.
 
 > **Note:** Water Heater entities share the `ESPHOME_CLIMATE` binding class and
 > are controlled via the ESPHome Climate sub-driver. Device modes (such as Eco,
@@ -536,8 +541,9 @@ bindings are created separately from the entity bindings above:
 
 > **Note:** Event entities are stateless triggers (button presses, gestures,
 > doorbell rings). Each discovered event type creates a Control4 event that can
-> be used in programming. The `{name} Last Event` variable tracks the most
-> recent event type.
+> be used in programming, plus a `BUTTON_LINK` connection named
+> `{name} {event_type}` that can be bound straight to a load. The
+> `{name} Last Event` variable tracks the most recent event type.
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -919,6 +919,12 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ## Unreleased
 
+### Added
+
+- Added a button connection for each event type an ESPHome event entity
+  declares, so a touch button or gesture on the device can drive a light, scene
+  or any other load directly, without Programming.
+
 ### Fixed
 
 - Fixed an automatic update sometimes leaving companion drivers on the previous

--- a/drivers/esphome/www/documentation/index.md
+++ b/drivers/esphome/www/documentation/index.md
@@ -587,15 +587,20 @@ the matching read-only Device Info properties.
 | Cover         | `CONTACT_SENSOR`                | Open/closed state contacts                                        |
 | Cover         | `RELAY`                         | Open/close/stop control relays                                    |
 | Button        | `BUTTON_LINK`                   | Allows other devices to trigger button                            |
+| Event         | `BUTTON_LINK`                   | One connection per event type, triggers other devices             |
 | Climate       | `ESPHOME_CLIMATE`               | Bind to ESPHome Climate sub-driver [\*\*](#climate-services-note) |
 | Fan           | `ESPHOME_FAN_N_SPEED[_REVERSE]` | Bind to ESPHome Fan sub-driver                                    |
 | Light         | `ESPHOME_LIGHT`                 | Bind to ESPHome Light sub-driver                                  |
 | Lock          | `ESPHOME_LOCK`                  | Bind to ESPHome Lock sub-driver                                   |
 | Water Heater  | `ESPHOME_CLIMATE`               | Bind to ESPHome Climate sub-driver                                |
 
-> **Note:** Sensor, Number, Select, Text, Text Sensor, Date, Time, Datetime, and
-> Event entities do not create bindings. They expose data only through variables
-> and events.
+> **Note:** Sensor, Number, Select, Text, Text Sensor, Date, Time and Datetime
+> entities do not create bindings. They expose data only through variables and
+> events.
+
+> **Note:** The Button and Event binding classes are the same but point opposite
+> ways. A Button binding lets another device press the ESPHome button; an Event
+> binding lets the ESPHome device act as a keypad button and drive a load.
 
 > **Note:** Water Heater entities share the `ESPHOME_CLIMATE` binding class and
 > are controlled via the ESPHome Climate sub-driver. Device modes (such as Eco,
@@ -636,8 +641,9 @@ bindings are created separately from the entity bindings above:
 
 > **Note:** Event entities are stateless triggers (button presses, gestures,
 > doorbell rings). Each discovered event type creates a Control4 event that can
-> be used in programming. The `{name} Last Event` variable tracks the most
-> recent event type.
+> be used in programming, plus a `BUTTON_LINK` connection named
+> `{name} {event_type}` that can be bound straight to a load. The
+> `{name} Last Event` variable tracks the most recent event type.
 
 ### Commands
 

--- a/src/esphome/entities/event.lua
+++ b/src/esphome/entities/event.lua
@@ -86,11 +86,10 @@ function EventEntity:updated(entity, state)
     return
   end
 
-  -- The device reports a completed event, not a press and release, so all three
-  -- go out together for whichever one the bound load acts on.
+  -- Click only. An event is a gesture the device already finished, so there is no
+  -- button-down to report: a DO_PUSH would start a hold ramp on a dimmer that the
+  -- following DO_RELEASE then freezes where it began, undoing the click.
   SendToProxy(binding.bindingId, "DO_CLICK", {}, "NOTIFY")
-  SendToProxy(binding.bindingId, "DO_PUSH", {}, "NOTIFY")
-  SendToProxy(binding.bindingId, "DO_RELEASE", {}, "NOTIFY")
 end
 
 return EventEntity

--- a/src/esphome/entities/event.lua
+++ b/src/esphome/entities/event.lua
@@ -42,9 +42,8 @@ function EventEntity:discovered(entity)
       entity.name .. " " .. eventType .. " event"
     )
 
-    -- One button link per event type, on the keypad side, so each type can drive a
-    -- different load. provider=false makes this driver the consumer, which is the
-    -- direction that sends button events rather than receives them.
+    -- provider=false is the keypad side: this driver sends button events rather
+    -- than receiving them, and each event type drives its own load.
     bindings:getOrAddDynamicBinding(
       self.TYPE,
       bindingKey(entity, eventType),
@@ -73,10 +72,8 @@ function EventEntity:updated(entity, state)
     return
   end
 
-  -- Update the last event variable
   values:update(entity.name .. " Last Event", eventType, "STRING")
 
-  -- Fire the corresponding C4 event
   events:fire("event_" .. entity.key, eventType)
   log:info("Fired event %s for %s", eventType, ESPHomeClient.describeEntity(entity))
 
@@ -86,9 +83,9 @@ function EventEntity:updated(entity, state)
     return
   end
 
-  -- Click only. An event is a gesture the device already finished, so there is no
-  -- button-down to report: a DO_PUSH would start a hold ramp on a dimmer that the
-  -- following DO_RELEASE then freezes where it began, undoing the click.
+  -- A gesture the device already finished has no button-down to report. Adding
+  -- DO_PUSH starts a hold ramp that the following DO_RELEASE freezes where it
+  -- began, undoing the click.
   SendToProxy(binding.bindingId, "DO_CLICK", {}, "NOTIFY")
 end
 

--- a/src/esphome/entities/event.lua
+++ b/src/esphome/entities/event.lua
@@ -1,4 +1,5 @@
 local log = require("lib.logging")
+local bindings = require("lib.bindings")
 local events = require("lib.events")
 local values = require("lib.values")
 local ESPHomeClient = require("esphome.client")
@@ -8,6 +9,14 @@ local EventEntity = {
   TYPE = ESPHomeClient.EntityType.EVENT,
 }
 EventEntity.__index = EventEntity
+
+--- Build the binding key for one of an entity's event types.
+--- @param entity table<string, any> The entity data received from the ESPHome client.
+--- @param eventType string The event type name declared by the entity.
+--- @return string key
+local function bindingKey(entity, eventType)
+  return "event_" .. entity.key .. ":" .. eventType
+end
 
 --- Create a new instance of the event entity.
 --- @param client ESPHomeClient The ESPHome client instance.
@@ -24,7 +33,6 @@ end
 function EventEntity:discovered(entity)
   log:trace("EventEntity:discovered(%s)", entity)
 
-  -- Register a C4 event for each event type
   local eventTypes = entity.event_types or {}
   for _, eventType in ipairs(eventTypes) do
     events:getOrAddEvent(
@@ -32,6 +40,18 @@ function EventEntity:discovered(entity)
       eventType,
       entity.name .. ": " .. eventType,
       entity.name .. " " .. eventType .. " event"
+    )
+
+    -- One button link per event type, on the keypad side, so each type can drive a
+    -- different load. provider=false makes this driver the consumer, which is the
+    -- direction that sends button events rather than receives them.
+    bindings:getOrAddDynamicBinding(
+      self.TYPE,
+      bindingKey(entity, eventType),
+      "CONTROL",
+      false,
+      entity.name .. " " .. eventType,
+      "BUTTON_LINK"
     )
   end
 
@@ -59,6 +79,18 @@ function EventEntity:updated(entity, state)
   -- Fire the corresponding C4 event
   events:fire("event_" .. entity.key, eventType)
   log:info("Fired event %s for %s", eventType, ESPHomeClient.describeEntity(entity))
+
+  local binding = bindings:getDynamicBinding(self.TYPE, bindingKey(entity, eventType))
+  if binding == nil then
+    log:warn("No button link for event type %s on %s", eventType, ESPHomeClient.describeEntity(entity))
+    return
+  end
+
+  -- The device reports a completed event, not a press and release, so all three
+  -- go out together for whichever one the bound load acts on.
+  SendToProxy(binding.bindingId, "DO_CLICK", {}, "NOTIFY")
+  SendToProxy(binding.bindingId, "DO_PUSH", {}, "NOTIFY")
+  SendToProxy(binding.bindingId, "DO_RELEASE", {}, "NOTIFY")
 end
 
 return EventEntity

--- a/test/c4_shim.lua
+++ b/test/c4_shim.lua
@@ -269,6 +269,25 @@ local connections = {}
 
 local BINDING_TYPE_IDS = { CONTROL = 1, PROXY = 2 }
 
+--- @type table<integer, { name: string, description: string }>
+local events = {}
+
+function C4:AddEvent(idEvent, strName, strDescription)
+  events[idEvent] = { name = strName, description = strDescription }
+end
+
+function C4:DeleteEvent(idEvent)
+  events[idEvent] = nil
+end
+
+function C4:FireEventByID(idEvent) end
+
+--- The events the driver has declared, keyed by event id.
+--- @return table<integer, { name: string, description: string }> events
+function ShimGetEvents()
+  return events
+end
+
 function C4:AddDynamicBinding(idBinding, strType, bIsProvider, strName, strClass, bHidden, bAutoBind)
   dynamic_bindings[idBinding] = {
     id = idBinding,

--- a/test/c4_shim.lua
+++ b/test/c4_shim.lua
@@ -809,8 +809,12 @@ function C4:AddEvent(idEvent, strName, strDescription)
   -- messages, while a number in either position is accepted, so the rule is
   -- "not nil" rather than "string". restoreEvents() replays persisted records,
   -- where a field can go missing, and that raise lands inside OnDriverLateInit.
-  assert(strName ~= nil, "name should be a string")
-  assert(strDescription ~= nil, "description should be a string")
+  if strName == nil then
+    error("name should be a string", 2)
+  end
+  if strDescription == nil then
+    error("description should be a string", 2)
+  end
   events[idEvent] = { name = strName, description = strDescription }
 end
 

--- a/test/c4_shim.lua
+++ b/test/c4_shim.lua
@@ -269,25 +269,6 @@ local connections = {}
 
 local BINDING_TYPE_IDS = { CONTROL = 1, PROXY = 2 }
 
---- @type table<integer, { name: string, description: string }>
-local events = {}
-
-function C4:AddEvent(idEvent, strName, strDescription)
-  events[idEvent] = { name = strName, description = strDescription }
-end
-
-function C4:DeleteEvent(idEvent)
-  events[idEvent] = nil
-end
-
-function C4:FireEventByID(idEvent) end
-
---- The events the driver has declared, keyed by event id.
---- @return table<integer, { name: string, description: string }> events
-function ShimGetEvents()
-  return events
-end
-
 function C4:AddDynamicBinding(idBinding, strType, bIsProvider, strName, strClass, bHidden, bAutoBind)
   dynamic_bindings[idBinding] = {
     id = idBinding,
@@ -809,6 +790,46 @@ end
 --- in the process, and under Fahrenheit a scale assertion can no longer fail.
 function ShimResetTemperatureScale()
   temperature_scale = DEFAULT_TEMPERATURE_SCALE
+end
+
+---------------------------------------------------------------------------
+-- Driver events
+-- C4:AddEvent declares an event a driver can fire and Programming can bind to.
+-- Declaration is the half worth recording: firing is one-way on a controller,
+-- with nothing readable afterwards, so FireEventByID accepts and drops. On a
+-- controller AddEvent is unavailable before OnDriverLateInit; the shim does not
+-- model that, so a test cannot lean on it to prove ordering.
+---------------------------------------------------------------------------
+
+--- @type table<integer, { name: string, description: string }>
+local events = {}
+
+function C4:AddEvent(idEvent, strName, strDescription)
+  -- Measured on a controller: a nil name or description raises with these
+  -- messages, while a number in either position is accepted, so the rule is
+  -- "not nil" rather than "string". restoreEvents() replays persisted records,
+  -- where a field can go missing, and that raise lands inside OnDriverLateInit.
+  assert(strName ~= nil, "name should be a string")
+  assert(strDescription ~= nil, "description should be a string")
+  events[idEvent] = { name = strName, description = strDescription }
+end
+
+function C4:DeleteEvent(idEvent)
+  events[idEvent] = nil
+end
+
+function C4:FireEventByID(idEvent) end
+
+--- The events the driver has declared, keyed by event id.
+--- @return table<integer, { name: string, description: string }> events
+function ShimEvents()
+  return events
+end
+
+--- Restore the empty registry. Declarations a test leaves behind carry into
+--- every later test in the same process.
+function ShimResetEvents()
+  events = {}
 end
 
 ---------------------------------------------------------------------------

--- a/test/test_event_button_link.lua
+++ b/test/test_event_button_link.lua
@@ -1,0 +1,73 @@
+-- Tests the button link an event entity publishes for each of its event types.
+--
+-- The send is one DO_CLICK and nothing else. A DO_PUSH alongside it starts a
+-- hold ramp on a bound dimmer, and a following DO_RELEASE freezes that ramp
+-- where it began, so the click is undone at the moment it starts. An ESPHome
+-- event is a gesture the device has already completed, so there is no
+-- button-down to report in the first place.
+--
+-- Run from the driver root:
+--   make test
+-- or:
+--   ./test/run_test.sh test_event_button_link.lua
+
+require("drivers-common-public.global.lib")
+require("c4_shim")
+
+local T = require("testlib")
+
+local bindings = require("lib.bindings")
+local EventEntity = require("esphome.entities.event")
+
+-- Captured below lib.utils' SendToProxy wrapper rather than in place of it, so
+-- the wrapper stays in the path under test.
+local sent = {}
+function C4:SendToProxy(idBinding, strCommand)
+  sent[#sent + 1] = tostring(idBinding) .. ":" .. tostring(strCommand)
+end
+
+local entity = { key = 42, name = "Touch", event_types = { "press", "long_press" } }
+local instance = EventEntity:new({})
+instance:discovered(entity)
+
+T.section("Discovery publishes one keypad binding per declared event type")
+
+local press = bindings:getDynamicBinding(EventEntity.TYPE, "event_42:press")
+local long = bindings:getDynamicBinding(EventEntity.TYPE, "event_42:long_press")
+
+T.eq("press binding exists", press ~= nil, true)
+T.eq("long_press binding exists", long ~= nil, true)
+T.eq("distinct binding ids", press.bindingId ~= long.bindingId, true)
+T.eq("class", press.class, "BUTTON_LINK")
+T.eq("type", press.type, "CONTROL")
+-- provider=false is the keypad side: it sends button events rather than
+-- receiving them, which is what makes the connection an Input in Composer.
+T.eq("consumer side", press.provider, false)
+T.eq("display name", long.displayName, "Touch long_press")
+
+-- The Control4 events for Programming are published alongside the bindings, so
+-- an event type can be used either way.
+local declared = {}
+for _, event in pairs(ShimGetEvents()) do
+  declared[event.name] = true
+end
+T.eq("programming event for press", declared["Touch: press"], true)
+T.eq("programming event for long_press", declared["Touch: long_press"], true)
+
+T.section("An event sends exactly one DO_CLICK, on its own type's binding")
+
+sent = {}
+instance:updated(entity, { event_type = "press" })
+T.eq("press", table.concat(sent, ","), press.bindingId .. ":DO_CLICK")
+
+sent = {}
+instance:updated(entity, { event_type = "long_press" })
+T.eq("long_press", table.concat(sent, ","), long.bindingId .. ":DO_CLICK")
+
+T.section("An undeclared event type sends nothing")
+
+sent = {}
+instance:updated(entity, { event_type = "triple_press" })
+T.eq("no binding, no send", table.concat(sent, ","), "")
+
+T.finish()

--- a/test/test_event_button_link.lua
+++ b/test/test_event_button_link.lua
@@ -1,10 +1,8 @@
 -- Tests the button link an event entity publishes for each of its event types.
 --
--- The send is one DO_CLICK and nothing else. A DO_PUSH alongside it starts a
--- hold ramp on a bound dimmer, and a following DO_RELEASE freezes that ramp
--- where it began, so the click is undone at the moment it starts. An ESPHome
--- event is a gesture the device has already completed, so there is no
--- button-down to report in the first place.
+-- The assertion that matters is one DO_CLICK and nothing else: a DO_PUSH and
+-- DO_RELEASE alongside it cancel the click on a bound dimmer. entities/event.lua
+-- carries the mechanism.
 --
 -- Run from the driver root:
 --   make test
@@ -40,13 +38,11 @@ T.eq("long_press binding exists", long ~= nil, true)
 T.eq("distinct binding ids", press.bindingId ~= long.bindingId, true)
 T.eq("class", press.class, "BUTTON_LINK")
 T.eq("type", press.type, "CONTROL")
--- provider=false is the keypad side: it sends button events rather than
--- receiving them, which is what makes the connection an Input in Composer.
+-- provider=false is what makes the connection an Input in Composer.
 T.eq("consumer side", press.provider, false)
 T.eq("display name", long.displayName, "Touch long_press")
 
--- The Control4 events for Programming are published alongside the bindings, so
--- an event type can be used either way.
+-- An event type stays usable from Programming as well as from a connection.
 local declared = {}
 for _, event in pairs(ShimEvents()) do
   declared[event.name] = true

--- a/test/test_event_button_link.lua
+++ b/test/test_event_button_link.lua
@@ -48,7 +48,7 @@ T.eq("display name", long.displayName, "Touch long_press")
 -- The Control4 events for Programming are published alongside the bindings, so
 -- an event type can be used either way.
 local declared = {}
-for _, event in pairs(ShimGetEvents()) do
+for _, event in pairs(ShimEvents()) do
   declared[event.name] = true
 end
 T.eq("programming event for press", declared["Touch: press"], true)


### PR DESCRIPTION
Closes #103.

An ESPHome `event:` entity previously created only Control4 events and a
`Last Event` variable, so a touch button on the device could reach a light
only through Programming. Each declared event type now also gets its own
`BUTTON_LINK` connection on the keypad side, bindable straight to a load in
Composer.

`button:` entities are unchanged. Their connection points the other way and
that stays correct: ESPHome has no message for a device-side button press, so
a `button:` can only ever be pressed by the controller.

One event sends one `DO_CLICK`. `DO_CLICK`, `DO_PUSH` and `DO_RELEASE` are
three phases of one press gesture, not three dialects to cover: a load that
implements all of them reads the triple as a click immediately followed by a
hold that ends where it began, and the click is undone. An ESPHome event is a
gesture the device has already completed, so there is no button-down to report.

## Verification

Run against a mock carrying both a dimmable light and an `event` entity on one
device, so a real event drives a real load through a real binding.

Discovery created one binding per declared type, all reported by the director as
`BUTTON_LINK` / **Input**, alongside a `button:` entity binding that stayed
**Output**:

```
bindingId 11  Test Button press          BUTTON_LINK  Input
bindingId 12  Test Button double_press   BUTTON_LINK  Input
bindingId 13  Test Button long_press     BUTTON_LINK  Input
bindingId 10  Test Action Button         BUTTON_LINK  Output
```

Measuring the light component's own state rather than the driver's, a Toggle
button link driven from the same live binding:

```
start        messages     final state              verdict
OFF          DO_CLICK     on=1 brightness=1.000    correct
OFF          triple       on=1 brightness=0.060    wrong, should be 1.000
ON  1.000    triple       on=1 brightness=0.990    wrong, should be off
ON  0.990    DO_CLICK     on=0 brightness=0.000    correct
```

The two stuck cases are the ramp getting a single step in before
`brightnessRampStopped()` freezes it.

End to end after the fix, a real repeated `event.trigger("press")` alternates
cleanly:

```
FIRING probe press -> on=1 brightness=1.000
FIRING probe press -> on=0 brightness=0.000
FIRING probe press -> on=1 brightness=1.000
```

`test/test_event_button_link.lua` asserts one `DO_CLICK` and nothing else, on
the binding for that event type. Reverting to the triple fails it.

## Note for the merger

`test/c4_shim.lua` is template-managed and this repo is pinned at `v0.9.21`, so
the stubs here are a local divergence until
finitelabs/control4-driver-template#55 lands and is tagged. Merge that first, so
the next copier update is a no-op on this file rather than a conflict.

The same self-cancelling triple is pre-existing in `esphome_bthome` and
`esphome_switchbot`; tracked in DRV-120, out of scope here.
