### PR TITLE
chore: update to template v0.9.22

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.9.21
+_commit: v0.9.22
 _src_path: git@github.com:finitelabs/control4-driver-template.git
 distributions: drivercentral oss
 github_org: finitelabs

--- a/test/c4_shim.lua
+++ b/test/c4_shim.lua
@@ -793,6 +793,50 @@ function ShimResetTemperatureScale()
 end
 
 ---------------------------------------------------------------------------
+-- Driver events
+-- C4:AddEvent declares an event a driver can fire and Programming can bind to.
+-- Declaration is the half worth recording: firing is one-way on a controller,
+-- with nothing readable afterwards, so FireEventByID accepts and drops. On a
+-- controller AddEvent is unavailable before OnDriverLateInit; the shim does not
+-- model that, so a test cannot lean on it to prove ordering.
+---------------------------------------------------------------------------
+
+--- @type table<integer, { name: string, description: string }>
+local events = {}
+
+function C4:AddEvent(idEvent, strName, strDescription)
+  -- Measured on a controller: a nil name or description raises with these
+  -- messages, while a number in either position is accepted, so the rule is
+  -- "not nil" rather than "string". restoreEvents() replays persisted records,
+  -- where a field can go missing, and that raise lands inside OnDriverLateInit.
+  if strName == nil then
+    error("name should be a string", 2)
+  end
+  if strDescription == nil then
+    error("description should be a string", 2)
+  end
+  events[idEvent] = { name = strName, description = strDescription }
+end
+
+function C4:DeleteEvent(idEvent)
+  events[idEvent] = nil
+end
+
+function C4:FireEventByID(idEvent) end
+
+--- The events the driver has declared, keyed by event id.
+--- @return table<integer, { name: string, description: string }> events
+function ShimEvents()
+  return events
+end
+
+--- Restore the empty registry. Declarations a test leaves behind carry into
+--- every later test in the same process.
+function ShimResetEvents()
+  events = {}
+end
+
+---------------------------------------------------------------------------
 -- Project devices
 -- C4:GetDevices / GetDeviceDisplayName / GetDeviceVariables read a registry a
 -- test populates with ShimSetDevices. An id absent from it is the nameless,

--- a/test/test_c4_shim.lua
+++ b/test/test_c4_shim.lua
@@ -591,5 +591,42 @@ ShimResetTemperatureScale()
 T.eq("and resets back to the default", C4:GetTemperatureScale(), "CELSIUS")
 
 --------------------------------------------------------------------------------
+T.section("C4:AddEvent / C4:DeleteEvent / C4:FireEventByID")
+--------------------------------------------------------------------------------
+
+C4:AddEvent(7, "Button: press", "Fired on a press")
+C4:AddEvent(8, "Button: long_press", "Fired on a long press")
+
+T.eq("records a declared event by id", ShimEvents()[7].name, "Button: press")
+T.eq("keeps its description", ShimEvents()[7].description, "Fired on a press")
+
+-- Firing is one-way on a controller, so the shim accepts it and records nothing.
+-- The assertion is that a driver firing an event does not disturb the
+-- declarations, which is the half a test can read back.
+C4:FireEventByID(7)
+T.eq("firing leaves the declaration alone", ShimEvents()[7].name, "Button: press")
+
+C4:DeleteEvent(7)
+T.eq("delete removes it", ShimEvents()[7], nil)
+T.eq("and leaves the others", ShimEvents()[8].name, "Button: long_press")
+
+-- Measured on a controller: a nil in either position raises, a number does not.
+T.raises("a nil name is refused", function()
+  C4:AddEvent(9, nil, "Fired on a press")
+end, "name should be a string")
+T.raises("a nil description is refused", function()
+  C4:AddEvent(9, "Button: press", nil)
+end, "description should be a string")
+
+-- Level 2, so the raise names the line that passed the nil. restoreEvents()
+-- replays persisted records, and that caller is the one worth pointing at.
+T.raisesAt("a rejected event blames the caller, not the shim", function()
+  C4:AddEvent(9, nil, "Fired on a press")
+end)
+
+ShimResetEvents()
+T.eq("reset clears every declaration", next(ShimEvents()), nil)
+
+--------------------------------------------------------------------------------
 
 T.finish()

--- a/vendor/bitn.lua
+++ b/vendor/bitn.lua
@@ -293,53 +293,82 @@ do
       return "pure Lua"
     end
 
+    -- 4-bit truth tables, indexed [a * 16 + b + 1], so each op is at most 8 steps.
+    local AND4, OR4, XOR4 = {}, {}, {}
+    for a = 0, 15 do
+      for b = 0, 15 do
+        local x, y, r_and, r_or, r_xor, bit_val = a, b, 0, 0, 0, 1
+        for _ = 1, 4 do
+          local xb, yb = x % 2, y % 2
+          if xb == 1 and yb == 1 then
+            r_and = r_and + bit_val
+          end
+          if xb == 1 or yb == 1 then
+            r_or = r_or + bit_val
+          end
+          if xb ~= yb then
+            r_xor = r_xor + bit_val
+          end
+          x, y, bit_val = (x - xb) / 2, (y - yb) / 2, bit_val * 2
+        end
+        local i = a * 16 + b + 1
+        AND4[i], OR4[i], XOR4[i] = r_and, r_or, r_xor
+      end
+    end
+
+    -- band(a, 2^k - 1) is a % 2^k. Built by doubling so the values are integers on 5.3+.
+    local LOW_MASK = {}
+    do
+      local m = 1
+      for _ = 1, 32 do
+        m = m * 2
+        LOW_MASK[m - 1] = m
+      end
+    end
+
     function _compat.band(a, b)
-      local r = 0
-      local bit_val = 1
-      for _ = 0, 31 do
-        if (a % 2 == 1) and (b % 2 == 1) then
-          r = r + bit_val
-        end
-        a = math_floor(a / 2)
-        b = math_floor(b / 2)
-        bit_val = bit_val * 2
-        if a == 0 and b == 0 then
-          break
-        end
+      a, b = math_floor(a) % 0x100000000, math_floor(b) % 0x100000000
+      local m = LOW_MASK[b] or LOW_MASK[a]
+      if m then
+        return (LOW_MASK[b] and a or b) % m
+      end
+      local r, scale = 0, 1
+      while a > 0 and b > 0 do
+        local na, nb = a % 16, b % 16
+        r = r + AND4[na * 16 + nb + 1] * scale
+        a, b, scale = (a - na) / 16, (b - nb) / 16, scale * 16
       end
       return r
     end
 
     function _compat.bor(a, b)
-      local r = 0
-      local bit_val = 1
-      for _ = 0, 31 do
-        if (a % 2 == 1) or (b % 2 == 1) then
-          r = r + bit_val
-        end
-        a = math_floor(a / 2)
-        b = math_floor(b / 2)
-        bit_val = bit_val * 2
-        if a == 0 and b == 0 then
-          break
-        end
+      a, b = math_floor(a) % 0x100000000, math_floor(b) % 0x100000000
+      if a == 0 then
+        return b
+      elseif b == 0 then
+        return a
+      end
+      local r, scale = 0, 1
+      while a > 0 or b > 0 do
+        local na, nb = a % 16, b % 16
+        r = r + OR4[na * 16 + nb + 1] * scale
+        a, b, scale = (a - na) / 16, (b - nb) / 16, scale * 16
       end
       return r
     end
 
     function _compat.bxor(a, b)
-      local r = 0
-      local bit_val = 1
-      for _ = 0, 31 do
-        if (a % 2) ~= (b % 2) then
-          r = r + bit_val
-        end
-        a = math_floor(a / 2)
-        b = math_floor(b / 2)
-        bit_val = bit_val * 2
-        if a == 0 and b == 0 then
-          break
-        end
+      a, b = math_floor(a) % 0x100000000, math_floor(b) % 0x100000000
+      if a == 0 then
+        return b
+      elseif b == 0 then
+        return a
+      end
+      local r, scale = 0, 1
+      while a > 0 or b > 0 do
+        local na, nb = a % 16, b % 16
+        r = r + XOR4[na * 16 + nb + 1] * scale
+        a, b, scale = (a - na) / 16, (b - nb) / 16, scale * 16
       end
       return r
     end
@@ -570,7 +599,12 @@ do
     --- @return integer n 16-bit unsigned integer
     function bit16.be_bytes_to_u16(str, offset)
       offset = offset or 1
-      assert(#str >= offset + 1, "Insufficient bytes for u16")
+      if offset ~= offset or offset < 1 then
+        error("Offset must be at least 1")
+      end
+      if #str < offset + 1 then
+        error("Insufficient bytes for u16")
+      end
       local b1, b2 = string_byte(str, offset, offset + 1)
       return b1 * 256 + b2
     end
@@ -581,7 +615,12 @@ do
     --- @return integer n 16-bit unsigned integer
     function bit16.le_bytes_to_u16(str, offset)
       offset = offset or 1
-      assert(#str >= offset + 1, "Insufficient bytes for u16")
+      if offset ~= offset or offset < 1 then
+        error("Offset must be at least 1")
+      end
+      if #str < offset + 1 then
+        error("Insufficient bytes for u16")
+      end
       local b1, b2 = string_byte(str, offset, offset + 1)
       return b1 + b2 * 256
     end
@@ -797,6 +836,26 @@ do
         end
       end
 
+      local decoder_errors = {
+        { "le_bytes_to_u16 rejects offset 0", bit16.le_bytes_to_u16, "\1\2\3", 0, "Offset must be at least 1" },
+        { "be_bytes_to_u16 rejects offset 0", bit16.be_bytes_to_u16, "\1\2\3", 0, "Offset must be at least 1" },
+        { "le_bytes_to_u16 rejects a NaN offset", bit16.le_bytes_to_u16, "\1\2\3", 0 / 0, "Offset must be at least 1" },
+        { "be_bytes_to_u16 rejects a NaN offset", bit16.be_bytes_to_u16, "\1\2\3", 0 / 0, "Offset must be at least 1" },
+        { "le_bytes_to_u16 rejects a short buffer", bit16.le_bytes_to_u16, "\1", 1, "Insufficient bytes for u16" },
+        { "be_bytes_to_u16 rejects a short buffer", bit16.be_bytes_to_u16, "\1\2", 2, "Insufficient bytes for u16" },
+      }
+      for _, test in ipairs(decoder_errors) do
+        local test_name, fn, input, offset, message = test[1], test[2], test[3], test[4], test[5]
+        total = total + 1
+        local raised, err_text = pcall(fn, input, offset)
+        if not raised and type(err_text) == "string" and string.find(err_text, message, 1, true) then
+          print("  PASS: " .. test_name)
+          passed = passed + 1
+        else
+          print("  FAIL: " .. test_name)
+        end
+      end
+
       print(string.format("\n16-bit operations: %d/%d tests passed\n", passed, total))
       return passed == total
     end
@@ -942,6 +1001,17 @@ do
     --- @return integer result Unsigned 32-bit value (0 to 0xFFFFFFFF)
     function bit32.to_unsigned(n)
       return compat_to_unsigned(n)
+    end
+
+    --- Convert unsigned 32-bit value to signed.
+    --- The inverse of `to_unsigned`: values of 2^31 and above wrap to negative.
+    --- @param n number Unsigned 32-bit value (already-signed values pass through)
+    --- @return integer result Signed 32-bit value (-2^31 to 2^31 - 1)
+    function bit32.to_signed(n)
+      if n >= 0x80000000 then
+        return n - 0x100000000
+      end
+      return n
     end
 
     --- Ensure value fits in 32-bit unsigned integer.
@@ -1111,12 +1181,19 @@ do
 
     local string_char = string.char
     local string_byte = string.byte
+    local string_pack = rawget(string, "pack")
+    local string_unpack = rawget(string, "unpack")
+    -- % is the whole operation on the pure Lua backend; skip the call.
+    local fast_band = _compat.has_native_ops or _compat.has_bit_lib
 
     --- Convert 32-bit unsigned integer to 4 bytes (big-endian).
     --- @param n integer 32-bit unsigned integer
     --- @return string bytes 4-byte string in big-endian order
     function bit32.u32_to_be_bytes(n)
-      n = compat_band(n, MASK32)
+      if string_pack then
+        return string_pack(">I4", n % 0x100000000)
+      end
+      n = fast_band and compat_band(n, MASK32) or n % 0x100000000
       return string_char(
         math_floor(n / 16777216) % 256,
         math_floor(n / 65536) % 256,
@@ -1129,7 +1206,10 @@ do
     --- @param n integer 32-bit unsigned integer
     --- @return string bytes 4-byte string in little-endian order
     function bit32.u32_to_le_bytes(n)
-      n = compat_band(n, MASK32)
+      if string_pack then
+        return string_pack("<I4", n % 0x100000000)
+      end
+      n = fast_band and compat_band(n, MASK32) or n % 0x100000000
       return string_char(
         math_floor(n % 256),
         math_floor(n / 256) % 256,
@@ -1144,7 +1224,15 @@ do
     --- @return integer n 32-bit unsigned integer
     function bit32.be_bytes_to_u32(str, offset)
       offset = offset or 1
-      assert(#str >= offset + 3, "Insufficient bytes for u32")
+      if offset ~= offset or offset < 1 then
+        error("Offset must be at least 1")
+      end
+      if #str < offset + 3 then
+        error("Insufficient bytes for u32")
+      end
+      if string_unpack then
+        return (string_unpack(">I4", str, offset))
+      end
       local b1, b2, b3, b4 = string_byte(str, offset, offset + 3)
       return b1 * 16777216 + b2 * 65536 + b3 * 256 + b4
     end
@@ -1155,7 +1243,15 @@ do
     --- @return integer n 32-bit unsigned integer
     function bit32.le_bytes_to_u32(str, offset)
       offset = offset or 1
-      assert(#str >= offset + 3, "Insufficient bytes for u32")
+      if offset ~= offset or offset < 1 then
+        error("Offset must be at least 1")
+      end
+      if #str < offset + 3 then
+        error("Insufficient bytes for u32")
+      end
+      if string_unpack then
+        return (string_unpack("<I4", str, offset))
+      end
       local b1, b2, b3, b4 = string_byte(str, offset, offset + 3)
       return b1 + b2 * 256 + b3 * 65536 + b4 * 16777216
     end
@@ -1170,6 +1266,10 @@ do
     --- Run comprehensive self-test with test vectors.
     --- @return boolean result True if all tests pass, false otherwise
     function bit32.selftest()
+      local function fmt32(v)
+        return v < 0 and tostring(v) or string.format("0x%08X", v)
+      end
+
       print("Running 32-bit operations test vectors...")
       print(string.format("  Using: %s", impl_name()))
       local passed = 0
@@ -1192,6 +1292,15 @@ do
         { name = "to_unsigned(-1)", fn = bit32.to_unsigned, inputs = { -1 }, expected = 0xFFFFFFFF },
         { name = "to_unsigned(-2147483648)", fn = bit32.to_unsigned, inputs = { -2147483648 }, expected = 0x80000000 },
         { name = "to_unsigned(-2147483647)", fn = bit32.to_unsigned, inputs = { -2147483647 }, expected = 0x80000001 },
+
+        -- to_signed tests
+        { name = "to_signed(0)", fn = bit32.to_signed, inputs = { 0 }, expected = 0 },
+        { name = "to_signed(1)", fn = bit32.to_signed, inputs = { 1 }, expected = 1 },
+        { name = "to_signed(0x7FFFFFFF)", fn = bit32.to_signed, inputs = { 0x7FFFFFFF }, expected = 0x7FFFFFFF },
+        { name = "to_signed(0x80000000)", fn = bit32.to_signed, inputs = { 0x80000000 }, expected = -2147483648 },
+        { name = "to_signed(0x80000001)", fn = bit32.to_signed, inputs = { 0x80000001 }, expected = -2147483647 },
+        { name = "to_signed(0xFFFFFFFF)", fn = bit32.to_signed, inputs = { 0xFFFFFFFF }, expected = -1 },
+        { name = "to_signed(-1)", fn = bit32.to_signed, inputs = { -1 }, expected = -1 },
 
         -- band tests
         { name = "band(0xFF00FF00, 0x00FF00FF)", fn = bit32.band, inputs = { 0xFF00FF00, 0x00FF00FF }, expected = 0 },
@@ -1425,8 +1534,8 @@ do
             print("    Expected: " .. exp_hex)
             print("    Got:      " .. got_hex)
           else
-            print(string.format("    Expected: 0x%08X", test.expected))
-            print(string.format("    Got:      0x%08X", result))
+            print("    Expected: " .. fmt32(test.expected))
+            print("    Got:      " .. fmt32(result))
           end
         end
       end
@@ -1616,6 +1725,58 @@ do
         end
       end
 
+      total = total + 1
+      local mask_failures = {}
+      for k = 1, 32 do
+        if bit32.band(0xDEADBEEF, 2 ^ k - 1) ~= 0xDEADBEEF % 2 ^ k then
+          mask_failures[#mask_failures + 1] = k
+        end
+      end
+      if #mask_failures == 0 then
+        print("  PASS: band against every low-bit mask width")
+        passed = passed + 1
+      else
+        print("  FAIL: band against every low-bit mask width: " .. table.concat(mask_failures, ", "))
+      end
+
+      local decoder_errors = {
+        { "le_bytes_to_u32 rejects offset 0", bit32.le_bytes_to_u32, "\1\2\3\4\5", 0, "Offset must be at least 1" },
+        { "be_bytes_to_u32 rejects offset 0", bit32.be_bytes_to_u32, "\1\2\3\4\5", 0, "Offset must be at least 1" },
+        {
+          "le_bytes_to_u32 rejects a NaN offset",
+          bit32.le_bytes_to_u32,
+          "\1\2\3\4\5",
+          0 / 0,
+          "Offset must be at least 1",
+        },
+        {
+          "be_bytes_to_u32 rejects a NaN offset",
+          bit32.be_bytes_to_u32,
+          "\1\2\3\4\5",
+          0 / 0,
+          "Offset must be at least 1",
+        },
+        { "le_bytes_to_u32 rejects a short buffer", bit32.le_bytes_to_u32, "\1\2\3", 1, "Insufficient bytes for u32" },
+        {
+          "be_bytes_to_u32 rejects a short buffer",
+          bit32.be_bytes_to_u32,
+          "\1\2\3\4",
+          2,
+          "Insufficient bytes for u32",
+        },
+      }
+      for _, test in ipairs(decoder_errors) do
+        local test_name, fn, input, offset, message = test[1], test[2], test[3], test[4], test[5]
+        total = total + 1
+        local raised, err_text = pcall(fn, input, offset)
+        if not raised and type(err_text) == "string" and string.find(err_text, message, 1, true) then
+          print("  PASS: " .. test_name)
+          passed = passed + 1
+        else
+          print("  FAIL: " .. test_name)
+        end
+      end
+
       print(string.format("\n32-bit operations: %d/%d tests passed\n", passed, total))
       return passed == total
     end
@@ -1745,9 +1906,11 @@ do
     local bit32_raw_lshift = bit32.raw_lshift
     local bit32_raw_rshift = bit32.raw_rshift
     local bit32_rshift = bit32.rshift
-    local bit32_u32_to_be_bytes = bit32.u32_to_be_bytes
-    local bit32_u32_to_le_bytes = bit32.u32_to_le_bytes
     local impl_name = _compat.impl_name
+    local math_floor = math.floor
+    local string_char = string.char
+    local string_pack = rawget(string, "pack")
+    local string_unpack = rawget(string, "unpack")
 
     -- Private metatable for Int64 type identification
     local Int64Meta = { __name = "Int64" }
@@ -1989,14 +2152,40 @@ do
     --- @param x Int64HighLow 64-bit value {high, low}
     --- @return string bytes 8-byte string in big-endian order
     function bit64.u64_to_be_bytes(x)
-      return bit32_u32_to_be_bytes(x[1]) .. bit32_u32_to_be_bytes(x[2])
+      local high, low = x[1] % 0x100000000, x[2] % 0x100000000
+      if string_pack then
+        return string_pack(">I4I4", high, low)
+      end
+      return string_char(
+        math_floor(high / 16777216) % 256,
+        math_floor(high / 65536) % 256,
+        math_floor(high / 256) % 256,
+        math_floor(high % 256),
+        math_floor(low / 16777216) % 256,
+        math_floor(low / 65536) % 256,
+        math_floor(low / 256) % 256,
+        math_floor(low % 256)
+      )
     end
 
     --- Convert 64-bit value to 8 bytes (little-endian).
     --- @param x Int64HighLow 64-bit value {high, low}
     --- @return string bytes 8-byte string in little-endian order
     function bit64.u64_to_le_bytes(x)
-      return bit32_u32_to_le_bytes(x[2]) .. bit32_u32_to_le_bytes(x[1])
+      local high, low = x[1] % 0x100000000, x[2] % 0x100000000
+      if string_pack then
+        return string_pack("<I4I4", low, high)
+      end
+      return string_char(
+        math_floor(low % 256),
+        math_floor(low / 256) % 256,
+        math_floor(low / 65536) % 256,
+        math_floor(low / 16777216) % 256,
+        math_floor(high % 256),
+        math_floor(high / 256) % 256,
+        math_floor(high / 65536) % 256,
+        math_floor(high / 16777216) % 256
+      )
     end
 
     --- Convert 8 bytes to 64-bit value (big-endian).
@@ -2005,7 +2194,16 @@ do
     --- @return Int64HighLow value {high, low} 64-bit value
     function bit64.be_bytes_to_u64(str, offset)
       offset = offset or 1
-      assert(#str >= offset + 7, "Insufficient bytes for u64")
+      if offset ~= offset or offset < 1 then
+        error("Offset must be at least 1")
+      end
+      if #str < offset + 7 then
+        error("Insufficient bytes for u64")
+      end
+      if string_unpack then
+        local high, low = string_unpack(">I4I4", str, offset)
+        return setmetatable({ high, low }, Int64Meta)
+      end
       local high = bit32_be_bytes_to_u32(str, offset)
       local low = bit32_be_bytes_to_u32(str, offset + 4)
       return bit64.new(high, low)
@@ -2017,7 +2215,16 @@ do
     --- @return Int64HighLow value {high, low} 64-bit value
     function bit64.le_bytes_to_u64(str, offset)
       offset = offset or 1
-      assert(#str >= offset + 7, "Insufficient bytes for u64")
+      if offset ~= offset or offset < 1 then
+        error("Offset must be at least 1")
+      end
+      if #str < offset + 7 then
+        error("Insufficient bytes for u64")
+      end
+      if string_unpack then
+        local low, high = string_unpack("<I4I4", str, offset)
+        return setmetatable({ high, low }, Int64Meta)
+      end
       local low = bit32_le_bytes_to_u32(str, offset)
       local high = bit32_le_bytes_to_u32(str, offset + 4)
       return bit64.new(high, low)
@@ -2064,14 +2271,12 @@ do
     --- @param value number|Int64HighLow The number to convert (or Int64HighLow to pass through).
     --- @return Int64HighLow pair The {high_32, low_32} pair.
     function bit64.from_number(value)
-      if bit64.is_int64(value) then
+      if type(value) == "table" and getmetatable(value) == Int64Meta then
         --- @cast value Int64HighLow
         return value
       end
       --- @cast value -Int64HighLow
-      local low = math.floor(value % 0x100000000)
-      local high = math.floor(value / 0x100000000)
-      return bit64.new(high, low)
+      return setmetatable({ math_floor(value / 0x100000000) % 0x100000000, math_floor(value % 0x100000000) }, Int64Meta)
     end
 
     --- Checks if two {high, low} pairs are equal.
@@ -2631,6 +2836,18 @@ do
           inputs = { 0 },
           expected = { 0x00000000, 0x00000000 },
         },
+        {
+          name = "from_number(-1)",
+          fn = bit64.from_number,
+          inputs = { -1 },
+          expected = { 0xFFFFFFFF, 0xFFFFFFFF },
+        },
+        {
+          name = "from_number(-2^70) wraps to 64 bits",
+          fn = bit64.from_number,
+          inputs = { -(2 ^ 70) },
+          expected = { 0x00000000, 0x00000000 },
+        },
 
         -- eq tests
         { name = "eq({1,2}, {1,2})", fn = bit64.eq, inputs = { { 1, 2 }, { 1, 2 } }, expected = true },
@@ -3081,6 +3298,70 @@ do
         end
       end
 
+      total = total + 1
+      if 1 / bit64.from_number(-1 / math.huge)[1] > 0 then
+        print("  PASS: from_number(-0.0) gives a +0 high word")
+        passed = passed + 1
+      else
+        print("  FAIL: from_number(-0.0) gives a +0 high word")
+      end
+
+      local decoder_errors = {
+        {
+          "le_bytes_to_u64 rejects offset 0",
+          bit64.le_bytes_to_u64,
+          "\1\2\3\4\5\6\7\8\9",
+          0,
+          "Offset must be at least 1",
+        },
+        {
+          "be_bytes_to_u64 rejects offset 0",
+          bit64.be_bytes_to_u64,
+          "\1\2\3\4\5\6\7\8\9",
+          0,
+          "Offset must be at least 1",
+        },
+        {
+          "le_bytes_to_u64 rejects a NaN offset",
+          bit64.le_bytes_to_u64,
+          "\1\2\3\4\5\6\7\8\9",
+          0 / 0,
+          "Offset must be at least 1",
+        },
+        {
+          "be_bytes_to_u64 rejects a NaN offset",
+          bit64.be_bytes_to_u64,
+          "\1\2\3\4\5\6\7\8\9",
+          0 / 0,
+          "Offset must be at least 1",
+        },
+        {
+          "le_bytes_to_u64 rejects a short buffer",
+          bit64.le_bytes_to_u64,
+          "\1\2\3\4\5\6\7",
+          1,
+          "Insufficient bytes for u64",
+        },
+        {
+          "be_bytes_to_u64 rejects a short buffer",
+          bit64.be_bytes_to_u64,
+          "\1\2\3\4\5\6\7\8",
+          2,
+          "Insufficient bytes for u64",
+        },
+      }
+      for _, test in ipairs(decoder_errors) do
+        local test_name, fn, input, offset, message = test[1], test[2], test[3], test[4], test[5]
+        total = total + 1
+        local raised, err_text = pcall(fn, input, offset)
+        if not raised and type(err_text) == "string" and string.find(err_text, message, 1, true) then
+          print("  PASS: " .. test_name)
+          passed = passed + 1
+        else
+          print("  FAIL: " .. test_name)
+        end
+      end
+
       print(string.format("\n64-bit operations: %d/%d tests passed\n", passed, total))
       return passed == total
     end
@@ -3297,7 +3578,7 @@ local bitn = {
 }
 
 --- Library version (injected at build time for releases).
-local VERSION = "v0.6.2"
+local VERSION = "v0.6.3"
 
 --- Get the library version string.
 --- @return string version Version string (e.g., "v1.0.0" or "dev")

--- a/vendor/bthome.lua
+++ b/vendor/bthome.lua
@@ -3423,7 +3423,7 @@ bthome.UUID_V1_ENCRYPTED = bthome.parser.UUID_V1_ENCRYPTED
 bthome.UUID_V2 = bthome.parser.UUID_V2
 
 --- Library version (injected at build time for releases).
-local VERSION = "v0.1.4"
+local VERSION = "v0.1.5"
 
 --- Get the library version string.
 --- @return string version Version string (e.g., "v1.0.0" or "dev")

--- a/vendor/crypto.lua
+++ b/vendor/crypto.lua
@@ -12520,7 +12520,7 @@ local crypto = {
 local openssl_wrapper = crypto.openssl_wrapper
 
 --- Library version (injected at build time for releases).
-local VERSION = "v0.2.1"
+local VERSION = "v0.2.2"
 
 --- Enable or disable OpenSSL acceleration for the primitives that support it
 --- (hashing and AEAD). Opt-in and safe: when the lua-openssl binding is

--- a/vendor/noiseprotocol.lua
+++ b/vendor/noiseprotocol.lua
@@ -772,7 +772,7 @@ local utils = require("noiseprotocol.utils")
 local openssl_wrapper = require("crypto.openssl_wrapper")
 
 --- Module version
-local VERSION = "v0.6.3"
+local VERSION = "v0.6.4"
 
 --- Enable or disable OpenSSL acceleration
 --- @function use_openssl


### PR DESCRIPTION
`copier update` to control4-driver-template `v0.9.22`, two changes over v0.9.21:

- **control4-driver-template#55** — the test shim models the driver event surface (`C4:AddEvent`, `C4:DeleteEvent`, `C4:FireEventByID`, `ShimEvents`, `ShimResetEvents`). Test-only; `test/c4_shim.lua` and `test/test_c4_shim.lua`.
- **control4-driver-template#56** — the four core amalgams re-vendored from their release assets.

| amalgam | now | was |
|---|---|---|
| `bitn.lua` | v0.6.3 | v0.6.2 |
| `crypto.lua` | v0.2.2 | v0.2.1 |
| `noiseprotocol.lua` | v0.6.4 | v0.6.3 |
| `bthome.lua` | v0.1.5 | v0.1.4 |

`protobuf.lua` stays at v0.6.7 until lua-protobuf v0.6.8 is cut. The only functional change is bitn's: `bit32.to_signed`, faster byte helpers with offset guards, and nibble-table `band`/`bor`/`bxor` on the pure-Lua backend; on a controller (LuaJIT) only the byte helpers are reached. The update's diff is exactly the template's own v0.9.21..v0.9.22 diff plus `.copier-answers.yml`; no local drift. `make check` and `make test` pass locally.