### PR TITLE
feat: let event entities drive loads as keypad buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ## Unreleased
 
+### Added
+
+- Added a button connection for each event type an ESPHome event entity
+  declares, so a touch button or gesture on the device can drive a light, scene
+  or any other load directly, without Programming.
+
 ### Fixed
 
 - Fixed an automatic update sometimes leaving companion drivers on the previous

--- a/README.md
+++ b/README.md
@@ -487,15 +487,20 @@ the matching read-only Device Info properties.
 | Cover         | `CONTACT_SENSOR`                | Open/closed state contacts                                        |
 | Cover         | `RELAY`                         | Open/close/stop control relays                                    |
 | Button        | `BUTTON_LINK`                   | Allows other devices to trigger button                            |
+| Event         | `BUTTON_LINK`                   | One connection per event type, triggers other devices             |
 | Climate       | `ESPHOME_CLIMATE`               | Bind to ESPHome Climate sub-driver [\*\*](#climate-services-note) |
 | Fan           | `ESPHOME_FAN_N_SPEED[_REVERSE]` | Bind to ESPHome Fan sub-driver                                    |
 | Light         | `ESPHOME_LIGHT`                 | Bind to ESPHome Light sub-driver                                  |
 | Lock          | `ESPHOME_LOCK`                  | Bind to ESPHome Lock sub-driver                                   |
 | Water Heater  | `ESPHOME_CLIMATE`               | Bind to ESPHome Climate sub-driver                                |
 
-> **Note:** Sensor, Number, Select, Text, Text Sensor, Date, Time, Datetime, and
-> Event entities do not create bindings. They expose data only through variables
-> and events.
+> **Note:** Sensor, Number, Select, Text, Text Sensor, Date, Time and Datetime
+> entities do not create bindings. They expose data only through variables and
+> events.
+
+> **Note:** The Button and Event binding classes are the same but point opposite
+> ways. A Button binding lets another device press the ESPHome button; an Event
+> binding lets the ESPHome device act as a keypad button and drive a load.
 
 > **Note:** Water Heater entities share the `ESPHOME_CLIMATE` binding class and
 > are controlled via the ESPHome Climate sub-driver. Device modes (such as Eco,
@@ -536,8 +541,9 @@ bindings are created separately from the entity bindings above:
 
 > **Note:** Event entities are stateless triggers (button presses, gestures,
 > doorbell rings). Each discovered event type creates a Control4 event that can
-> be used in programming. The `{name} Last Event` variable tracks the most
-> recent event type.
+> be used in programming, plus a `BUTTON_LINK` connection named
+> `{name} {event_type}` that can be bound straight to a load. The
+> `{name} Last Event` variable tracks the most recent event type.
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -919,6 +919,12 @@ Template for a new release entry (copy below the heading, fill in, uncomment):
 
 ## Unreleased
 
+### Added
+
+- Added a button connection for each event type an ESPHome event entity
+  declares, so a touch button or gesture on the device can drive a light, scene
+  or any other load directly, without Programming.
+
 ### Fixed
 
 - Fixed an automatic update sometimes leaving companion drivers on the previous

--- a/drivers/esphome/www/documentation/index.md
+++ b/drivers/esphome/www/documentation/index.md
@@ -587,15 +587,20 @@ the matching read-only Device Info properties.
 | Cover         | `CONTACT_SENSOR`                | Open/closed state contacts                                        |
 | Cover         | `RELAY`                         | Open/close/stop control relays                                    |
 | Button        | `BUTTON_LINK`                   | Allows other devices to trigger button                            |
+| Event         | `BUTTON_LINK`                   | One connection per event type, triggers other devices             |
 | Climate       | `ESPHOME_CLIMATE`               | Bind to ESPHome Climate sub-driver [\*\*](#climate-services-note) |
 | Fan           | `ESPHOME_FAN_N_SPEED[_REVERSE]` | Bind to ESPHome Fan sub-driver                                    |
 | Light         | `ESPHOME_LIGHT`                 | Bind to ESPHome Light sub-driver                                  |
 | Lock          | `ESPHOME_LOCK`                  | Bind to ESPHome Lock sub-driver                                   |
 | Water Heater  | `ESPHOME_CLIMATE`               | Bind to ESPHome Climate sub-driver                                |
 
-> **Note:** Sensor, Number, Select, Text, Text Sensor, Date, Time, Datetime, and
-> Event entities do not create bindings. They expose data only through variables
-> and events.
+> **Note:** Sensor, Number, Select, Text, Text Sensor, Date, Time and Datetime
+> entities do not create bindings. They expose data only through variables and
+> events.
+
+> **Note:** The Button and Event binding classes are the same but point opposite
+> ways. A Button binding lets another device press the ESPHome button; an Event
+> binding lets the ESPHome device act as a keypad button and drive a load.
 
 > **Note:** Water Heater entities share the `ESPHOME_CLIMATE` binding class and
 > are controlled via the ESPHome Climate sub-driver. Device modes (such as Eco,
@@ -636,8 +641,9 @@ bindings are created separately from the entity bindings above:
 
 > **Note:** Event entities are stateless triggers (button presses, gestures,
 > doorbell rings). Each discovered event type creates a Control4 event that can
-> be used in programming. The `{name} Last Event` variable tracks the most
-> recent event type.
+> be used in programming, plus a `BUTTON_LINK` connection named
+> `{name} {event_type}` that can be bound straight to a load. The
+> `{name} Last Event` variable tracks the most recent event type.
 
 ### Commands
 

--- a/src/esphome/entities/event.lua
+++ b/src/esphome/entities/event.lua
@@ -86,11 +86,10 @@ function EventEntity:updated(entity, state)
     return
   end
 
-  -- The device reports a completed event, not a press and release, so all three
-  -- go out together for whichever one the bound load acts on.
+  -- Click only. An event is a gesture the device already finished, so there is no
+  -- button-down to report: a DO_PUSH would start a hold ramp on a dimmer that the
+  -- following DO_RELEASE then freezes where it began, undoing the click.
   SendToProxy(binding.bindingId, "DO_CLICK", {}, "NOTIFY")
-  SendToProxy(binding.bindingId, "DO_PUSH", {}, "NOTIFY")
-  SendToProxy(binding.bindingId, "DO_RELEASE", {}, "NOTIFY")
 end
 
 return EventEntity

--- a/src/esphome/entities/event.lua
+++ b/src/esphome/entities/event.lua
@@ -42,9 +42,8 @@ function EventEntity:discovered(entity)
       entity.name .. " " .. eventType .. " event"
     )
 
-    -- One button link per event type, on the keypad side, so each type can drive a
-    -- different load. provider=false makes this driver the consumer, which is the
-    -- direction that sends button events rather than receives them.
+    -- provider=false is the keypad side: this driver sends button events rather
+    -- than receiving them, and each event type drives its own load.
     bindings:getOrAddDynamicBinding(
       self.TYPE,
       bindingKey(entity, eventType),
@@ -73,10 +72,8 @@ function EventEntity:updated(entity, state)
     return
   end
 
-  -- Update the last event variable
   values:update(entity.name .. " Last Event", eventType, "STRING")
 
-  -- Fire the corresponding C4 event
   events:fire("event_" .. entity.key, eventType)
   log:info("Fired event %s for %s", eventType, ESPHomeClient.describeEntity(entity))
 
@@ -86,9 +83,9 @@ function EventEntity:updated(entity, state)
     return
   end
 
-  -- Click only. An event is a gesture the device already finished, so there is no
-  -- button-down to report: a DO_PUSH would start a hold ramp on a dimmer that the
-  -- following DO_RELEASE then freezes where it began, undoing the click.
+  -- A gesture the device already finished has no button-down to report. Adding
+  -- DO_PUSH starts a hold ramp that the following DO_RELEASE freezes where it
+  -- began, undoing the click.
   SendToProxy(binding.bindingId, "DO_CLICK", {}, "NOTIFY")
 end
 

--- a/src/esphome/entities/event.lua
+++ b/src/esphome/entities/event.lua
@@ -1,4 +1,5 @@
 local log = require("lib.logging")
+local bindings = require("lib.bindings")
 local events = require("lib.events")
 local values = require("lib.values")
 local ESPHomeClient = require("esphome.client")
@@ -8,6 +9,14 @@ local EventEntity = {
   TYPE = ESPHomeClient.EntityType.EVENT,
 }
 EventEntity.__index = EventEntity
+
+--- Build the binding key for one of an entity's event types.
+--- @param entity table<string, any> The entity data received from the ESPHome client.
+--- @param eventType string The event type name declared by the entity.
+--- @return string key
+local function bindingKey(entity, eventType)
+  return "event_" .. entity.key .. ":" .. eventType
+end
 
 --- Create a new instance of the event entity.
 --- @param client ESPHomeClient The ESPHome client instance.
@@ -24,7 +33,6 @@ end
 function EventEntity:discovered(entity)
   log:trace("EventEntity:discovered(%s)", entity)
 
-  -- Register a C4 event for each event type
   local eventTypes = entity.event_types or {}
   for _, eventType in ipairs(eventTypes) do
     events:getOrAddEvent(
@@ -32,6 +40,18 @@ function EventEntity:discovered(entity)
       eventType,
       entity.name .. ": " .. eventType,
       entity.name .. " " .. eventType .. " event"
+    )
+
+    -- One button link per event type, on the keypad side, so each type can drive a
+    -- different load. provider=false makes this driver the consumer, which is the
+    -- direction that sends button events rather than receives them.
+    bindings:getOrAddDynamicBinding(
+      self.TYPE,
+      bindingKey(entity, eventType),
+      "CONTROL",
+      false,
+      entity.name .. " " .. eventType,
+      "BUTTON_LINK"
     )
   end
 
@@ -59,6 +79,18 @@ function EventEntity:updated(entity, state)
   -- Fire the corresponding C4 event
   events:fire("event_" .. entity.key, eventType)
   log:info("Fired event %s for %s", eventType, ESPHomeClient.describeEntity(entity))
+
+  local binding = bindings:getDynamicBinding(self.TYPE, bindingKey(entity, eventType))
+  if binding == nil then
+    log:warn("No button link for event type %s on %s", eventType, ESPHomeClient.describeEntity(entity))
+    return
+  end
+
+  -- The device reports a completed event, not a press and release, so all three
+  -- go out together for whichever one the bound load acts on.
+  SendToProxy(binding.bindingId, "DO_CLICK", {}, "NOTIFY")
+  SendToProxy(binding.bindingId, "DO_PUSH", {}, "NOTIFY")
+  SendToProxy(binding.bindingId, "DO_RELEASE", {}, "NOTIFY")
 end
 
 return EventEntity

--- a/test/c4_shim.lua
+++ b/test/c4_shim.lua
@@ -269,6 +269,25 @@ local connections = {}
 
 local BINDING_TYPE_IDS = { CONTROL = 1, PROXY = 2 }
 
+--- @type table<integer, { name: string, description: string }>
+local events = {}
+
+function C4:AddEvent(idEvent, strName, strDescription)
+  events[idEvent] = { name = strName, description = strDescription }
+end
+
+function C4:DeleteEvent(idEvent)
+  events[idEvent] = nil
+end
+
+function C4:FireEventByID(idEvent) end
+
+--- The events the driver has declared, keyed by event id.
+--- @return table<integer, { name: string, description: string }> events
+function ShimGetEvents()
+  return events
+end
+
 function C4:AddDynamicBinding(idBinding, strType, bIsProvider, strName, strClass, bHidden, bAutoBind)
   dynamic_bindings[idBinding] = {
     id = idBinding,

--- a/test/c4_shim.lua
+++ b/test/c4_shim.lua
@@ -269,25 +269,6 @@ local connections = {}
 
 local BINDING_TYPE_IDS = { CONTROL = 1, PROXY = 2 }
 
---- @type table<integer, { name: string, description: string }>
-local events = {}
-
-function C4:AddEvent(idEvent, strName, strDescription)
-  events[idEvent] = { name = strName, description = strDescription }
-end
-
-function C4:DeleteEvent(idEvent)
-  events[idEvent] = nil
-end
-
-function C4:FireEventByID(idEvent) end
-
---- The events the driver has declared, keyed by event id.
---- @return table<integer, { name: string, description: string }> events
-function ShimGetEvents()
-  return events
-end
-
 function C4:AddDynamicBinding(idBinding, strType, bIsProvider, strName, strClass, bHidden, bAutoBind)
   dynamic_bindings[idBinding] = {
     id = idBinding,

--- a/test/test_event_button_link.lua
+++ b/test/test_event_button_link.lua
@@ -1,0 +1,73 @@
+-- Tests the button link an event entity publishes for each of its event types.
+--
+-- The send is one DO_CLICK and nothing else. A DO_PUSH alongside it starts a
+-- hold ramp on a bound dimmer, and a following DO_RELEASE freezes that ramp
+-- where it began, so the click is undone at the moment it starts. An ESPHome
+-- event is a gesture the device has already completed, so there is no
+-- button-down to report in the first place.
+--
+-- Run from the driver root:
+--   make test
+-- or:
+--   ./test/run_test.sh test_event_button_link.lua
+
+require("drivers-common-public.global.lib")
+require("c4_shim")
+
+local T = require("testlib")
+
+local bindings = require("lib.bindings")
+local EventEntity = require("esphome.entities.event")
+
+-- Captured below lib.utils' SendToProxy wrapper rather than in place of it, so
+-- the wrapper stays in the path under test.
+local sent = {}
+function C4:SendToProxy(idBinding, strCommand)
+  sent[#sent + 1] = tostring(idBinding) .. ":" .. tostring(strCommand)
+end
+
+local entity = { key = 42, name = "Touch", event_types = { "press", "long_press" } }
+local instance = EventEntity:new({})
+instance:discovered(entity)
+
+T.section("Discovery publishes one keypad binding per declared event type")
+
+local press = bindings:getDynamicBinding(EventEntity.TYPE, "event_42:press")
+local long = bindings:getDynamicBinding(EventEntity.TYPE, "event_42:long_press")
+
+T.eq("press binding exists", press ~= nil, true)
+T.eq("long_press binding exists", long ~= nil, true)
+T.eq("distinct binding ids", press.bindingId ~= long.bindingId, true)
+T.eq("class", press.class, "BUTTON_LINK")
+T.eq("type", press.type, "CONTROL")
+-- provider=false is the keypad side: it sends button events rather than
+-- receiving them, which is what makes the connection an Input in Composer.
+T.eq("consumer side", press.provider, false)
+T.eq("display name", long.displayName, "Touch long_press")
+
+-- The Control4 events for Programming are published alongside the bindings, so
+-- an event type can be used either way.
+local declared = {}
+for _, event in pairs(ShimGetEvents()) do
+  declared[event.name] = true
+end
+T.eq("programming event for press", declared["Touch: press"], true)
+T.eq("programming event for long_press", declared["Touch: long_press"], true)
+
+T.section("An event sends exactly one DO_CLICK, on its own type's binding")
+
+sent = {}
+instance:updated(entity, { event_type = "press" })
+T.eq("press", table.concat(sent, ","), press.bindingId .. ":DO_CLICK")
+
+sent = {}
+instance:updated(entity, { event_type = "long_press" })
+T.eq("long_press", table.concat(sent, ","), long.bindingId .. ":DO_CLICK")
+
+T.section("An undeclared event type sends nothing")
+
+sent = {}
+instance:updated(entity, { event_type = "triple_press" })
+T.eq("no binding, no send", table.concat(sent, ","), "")
+
+T.finish()

--- a/test/test_event_button_link.lua
+++ b/test/test_event_button_link.lua
@@ -1,10 +1,8 @@
 -- Tests the button link an event entity publishes for each of its event types.
 --
--- The send is one DO_CLICK and nothing else. A DO_PUSH alongside it starts a
--- hold ramp on a bound dimmer, and a following DO_RELEASE freezes that ramp
--- where it began, so the click is undone at the moment it starts. An ESPHome
--- event is a gesture the device has already completed, so there is no
--- button-down to report in the first place.
+-- The assertion that matters is one DO_CLICK and nothing else: a DO_PUSH and
+-- DO_RELEASE alongside it cancel the click on a bound dimmer. entities/event.lua
+-- carries the mechanism.
 --
 -- Run from the driver root:
 --   make test
@@ -40,13 +38,11 @@ T.eq("long_press binding exists", long ~= nil, true)
 T.eq("distinct binding ids", press.bindingId ~= long.bindingId, true)
 T.eq("class", press.class, "BUTTON_LINK")
 T.eq("type", press.type, "CONTROL")
--- provider=false is the keypad side: it sends button events rather than
--- receiving them, which is what makes the connection an Input in Composer.
+-- provider=false is what makes the connection an Input in Composer.
 T.eq("consumer side", press.provider, false)
 T.eq("display name", long.displayName, "Touch long_press")
 
--- The Control4 events for Programming are published alongside the bindings, so
--- an event type can be used either way.
+-- An event type stays usable from Programming as well as from a connection.
 local declared = {}
 for _, event in pairs(ShimEvents()) do
   declared[event.name] = true

--- a/test/test_event_button_link.lua
+++ b/test/test_event_button_link.lua
@@ -48,7 +48,7 @@ T.eq("display name", long.displayName, "Touch long_press")
 -- The Control4 events for Programming are published alongside the bindings, so
 -- an event type can be used either way.
 local declared = {}
-for _, event in pairs(ShimGetEvents()) do
+for _, event in pairs(ShimEvents()) do
   declared[event.name] = true
 end
 T.eq("programming event for press", declared["Touch: press"], true)


### PR DESCRIPTION
Closes #103. Re-opens the work from #110, which was merged without a go-ahead
and reverted in #112. Since then the branch has picked up template v0.9.22 (its
shim now carries the event stubs, so this branch has none) and `main` as of
#123.

An ESPHome `event:` entity previously created only Control4 events and a
`Last Event` variable, so a touch button on the device could reach a light
only through Programming. Each declared event type now also gets its own
`BUTTON_LINK` connection on the keypad side, which can be bound straight to a
load in Composer.

`button:` entities are unchanged. Their connection points the other way, which
stays correct: ESPHome has no message for a device-side button press, so a
`button:` can only ever be pressed by the controller.

## Protocol

An event sends `DO_PUSH` then `DO_CLICK`, the pair a Control4 keypad sends for a
tap. That matches what #121 settled for the BTHome and SwitchBot senders.

#110 sent `DO_CLICK` alone, to avoid double-firing the SwitchBot receiver and
because a push-then-click pair seemed unnecessary. Since #121:

- the SwitchBot receiver fires once per tap
- loads that act only on `DO_PUSH` (they exist) need the push to fire at all

`DO_RELEASE` is not sent, because it ends a hold rather than a click.

## Verification

Tested on a controller with a host-mode mock that carries a dimmable light and
an `event` entity on the same device.

Discovery creates one binding per declared type. The director reports each as
`BUTTON_LINK` / **Input**, while a `button:` entity's binding stays **Output**:

```
bindingId 11  Test Button press          BUTTON_LINK  Input
bindingId 12  Test Button double_press   BUTTON_LINK  Input
bindingId 13  Test Button long_press     BUTTON_LINK  Input
bindingId 10  Test Action Button         BUTTON_LINK  Output
```

End to end at this head: a device-side `event.trigger("press")` every 25s, with
the event bound to the light's Toggle button link. Each press toggles it cleanly,
read from the light component's own state:

```
08:26:50 FIRING probe press -> on=1 brightness=1.000
08:27:15 FIRING probe press -> on=0 brightness=0.000
08:27:40 FIRING probe press -> on=1 brightness=1.000
08:28:05 FIRING probe press -> on=0 brightness=0.000
```

`test/test_event_button_link.lua` asserts `DO_PUSH` then `DO_CLICK` and nothing
else, on the binding for the event type that fired. It fails for click only, for
the old triple, and for the pair in reverse order. `make check` is clean and all
suites are green.

`test_button_link_protocol.lua`'s "nothing sends DO_RELEASE" scan now also reads
`src/`, since `entities/event.lua` is the first sender outside `drivers/`. With
`DO_RELEASE` added to `event.lua` it now fails; before this change it passed.

## Known limitation

The binding key includes the event type. Renaming a type in YAML therefore
creates a new connection and leaves the old one in Composer, still bound but
dead. The Control4 event created just above behaves the same way, so this is
consistent, not new.
