### PR TITLE
chore: update to template v0.9.23

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.9.22
+_commit: v0.9.23
 _src_path: git@github.com:finitelabs/control4-driver-template.git
 distributions: drivercentral oss
 github_org: finitelabs

--- a/src/lib/utils.lua
+++ b/src/lib/utils.lua
@@ -845,13 +845,26 @@ function toboolean(val)
   return false
 end
 
+--- Converts a value to a finite number.
+--- `tonumber` passes NaN and infinity straight through, so a caller's `or`
+--- fallback never fires for them.
+--- @param value any The value to convert. Can be a number or a string that represents a number.
+--- @return number|nil number The number when it is finite, or `nil` otherwise.
+function tofinite(value)
+  value = tonumber(value)
+  if value == nil or value ~= value or value == math.huge or value == -math.huge then
+    return nil
+  end
+  return value
+end
+
 --- Converts a value to a valid integer.
 --- Rounds fractional numbers and validates string representations.
 --- @param value any The value to convert to an integer. Can be a number or a string that represents a number.
 --- @return integer|nil int Returns the rounded integer if the conversion is successful, or `nil` if the value cannot be converted.
 --- @overload fun(value: number): integer
 function tointeger(value)
-  value = tonumber(value)
+  value = tofinite(value)
   if value == nil then
     return nil
   end
@@ -990,6 +1003,92 @@ function c2f(c)
   return round(f, 1)
 end
 
+--- Temperature scale spellings seen on VALUE_CHANGED and on the thermostat
+--- proxy, reduced to a letter. The proxy sends "C"/"F", sensor bindings send
+--- the whole word, and C4:GetTemperatureScale() returns the whole word.
+--- @type table<string, string>
+local TEMPERATURE_SCALES = {
+  C = "C",
+  CELSIUS = "C",
+  F = "F",
+  FAHRENHEIT = "F",
+  K = "K",
+  KELVIN = "K",
+}
+
+--- Reduce a scale to "C", "F" or "K", or nil when it does not name a
+--- temperature (e.g. "PERCENT").
+--- @param scale string|nil The scale as it appears on the wire.
+--- @return string|nil letter
+function TemperatureScaleLetter(scale)
+  if type(scale) ~= "string" then
+    return nil
+  end
+  return TEMPERATURE_SCALES[scale:upper()]
+end
+
+--- Convert a temperature to Celsius from the scale it was reported in.
+--- @param value number The temperature.
+--- @param scale string|nil The scale of `value`; not a temperature scale yields nil.
+--- @return number|nil celsius
+function ToCelsius(value, scale)
+  if type(value) ~= "number" then
+    return nil
+  end
+  local letter = TemperatureScaleLetter(scale)
+  if letter == "C" then
+    return value
+  elseif letter == "F" then
+    return f2c(value)
+  elseif letter == "K" then
+    return round(value - 273.15, 1)
+  end
+  return nil
+end
+
+--- Build the VALUE_CHANGED params for a sensor binding.
+---
+--- C4-THERM reads a bound sensor from CELSIUS, requires TIMESTAMP, and drops
+--- readings older than 15 minutes; VALUE/SCALE consumers read the rest. VALUE
+--- stays in the measured scale so existing consumers are unaffected.
+--- @param value number The measured value.
+--- @param scale string|nil The scale of `value` (e.g. "CELSIUS", "PERCENT").
+--- @return table params
+function SensorValueParams(value, scale)
+  local params = {
+    VALUE = value,
+    SCALE = scale,
+    TIMESTAMP = os.time(),
+  }
+  local celsius = ToCelsius(value, scale)
+  if celsius ~= nil then
+    params.CELSIUS = celsius
+    params.FAHRENHEIT = c2f(celsius)
+  end
+  return params
+end
+
+--- Read a Celsius temperature out of VALUE_CHANGED params, accepting every key
+--- convention in use: CELSIUS, FAHRENHEIT, or VALUE carrying a SCALE.
+--- @param tParams table|nil The params as received.
+--- @param defaultScale string The scale to read VALUE in when SCALE is absent. Sensor bindings report Celsius; the thermostat proxy sends Fahrenheit.
+--- @return number|nil celsius
+function CelsiusFromParams(tParams, defaultScale)
+  local celsius = tonumber_expect_period(Select(tParams, "CELSIUS"))
+  if celsius ~= nil then
+    return celsius
+  end
+  local fahrenheit = tonumber_expect_period(Select(tParams, "FAHRENHEIT"))
+  if fahrenheit ~= nil then
+    return f2c(fahrenheit)
+  end
+  local value = tonumber_expect_period(Select(tParams, "VALUE"))
+  if value == nil then
+    return nil
+  end
+  return ToCelsius(value, Select(tParams, "SCALE") or defaultScale)
+end
+
 --------------------------------------------------------------------------------
 -- Binary-safe serialization
 --------------------------------------------------------------------------------
@@ -1000,6 +1099,15 @@ local BINARY_MARKER = "__b64"
 
 --- Sentinel value for nil (since Lua tables can't store nil values).
 local NIL_SENTINEL = "__null__"
+
+--- JSON has no NaN or infinity literal. JSON.lua emits `null` for a NaN, which
+--- decodes to a Lua `nil` indistinguishable from a key that was never set, and
+--- `1e+9999` for the infinities, which is out of range for a double and so is
+--- parser-dependent on the far side of a driver-to-driver hop. They travel as
+--- sentinels instead, like NIL_SENTINEL.
+local NAN_SENTINEL = "__nan__"
+local POS_INF_SENTINEL = "__inf__"
+local NEG_INF_SENTINEL = "__-inf__"
 
 --- Check if a byte is binary (unsafe for transport).
 --- Safe: 0x09 (tab), 0x0A (LF), 0x0D (CR), 0x20-0x7E (printable ASCII)
@@ -1044,9 +1152,24 @@ local function encodeBinaryStrings(value)
     return NIL_SENTINEL
   end
   local t = type(value)
+  if t == "number" then
+    if value ~= value then
+      return NAN_SENTINEL
+    elseif value == math.huge then
+      return POS_INF_SENTINEL
+    elseif value == -math.huge then
+      return NEG_INF_SENTINEL
+    end
+  end
   if t == "string" then
-    -- Encode if binary OR if it equals the sentinel (to avoid collision)
-    if needsBase64(value) or value == NIL_SENTINEL then
+    -- Encode if binary OR if it equals a sentinel (to avoid collision)
+    if
+      needsBase64(value)
+      or value == NIL_SENTINEL
+      or value == NAN_SENTINEL
+      or value == POS_INF_SENTINEL
+      or value == NEG_INF_SENTINEL
+    then
       return { [BINARY_MARKER] = C4:Base64Encode(value) }
     end
     return value
@@ -1069,6 +1192,15 @@ end
 local function decodeBinaryStrings(value)
   if value == NIL_SENTINEL then
     return nil
+  end
+  if value == NAN_SENTINEL then
+    return 0 / 0
+  end
+  if value == POS_INF_SENTINEL then
+    return math.huge
+  end
+  if value == NEG_INF_SENTINEL then
+    return -math.huge
   end
   if type(value) ~= "table" then
     return value

--- a/src/lib/values.lua
+++ b/src/lib/values.lua
@@ -23,6 +23,13 @@ local function ovcKey(name)
   return string.gsub(name, "%s+", "_")
 end
 
+--- Equality for a stored value. Differs from `==` only for NaN, which is never
+--- equal to itself: a driver republishing an unknown reading would otherwise
+--- report a change on every push and rewrite persistent storage each time.
+local function sameValue(a, b)
+  return a == b or (a ~= a and b ~= b)
+end
+
 --- @class Value
 --- @field index integer Index used for ordering values during restore.
 --- @field varType VariableType? Optional variable type if registered as a variable
@@ -134,7 +141,7 @@ function Values:update(name, value, varType, callbackOrWritable, propertySuffix)
 
   -- Check if the entry has changed
   local changed = not existing
-    or existing.value ~= value
+    or not sameValue(existing.value, value)
     or existing.suffix ~= propertySuffix
     or existing.varType ~= varType
     or existing.writable ~= writable

--- a/test/test_nonfinite_numbers.lua
+++ b/test/test_nonfinite_numbers.lua
@@ -1,0 +1,109 @@
+-- Tests for how a non-finite number travels through the shared libraries:
+-- `tofinite` coercion in lib/utils.lua, the SerializeSafe sentinels that carry
+-- NaN and infinity across a JSON hop, and NaN-aware change detection in
+-- `Values:update`.
+--
+-- Regression test for FL-15.
+--
+-- Run from the driver root:
+--   make test
+-- or:
+--   ./test/run_test.sh test_nonfinite_numbers.lua
+
+local T = require("testlib")
+
+require("c4_shim")
+require("lib.utils")
+
+local NAN = 0 / 0
+
+-- ── tofinite ─────────────────────────────────────────────────────────────────
+
+T.section("tofinite keeps finite numbers")
+T.eq("an integer", tofinite(3), 3)
+T.eq("a fraction", tofinite(-2.5), -2.5)
+T.eq("zero", tofinite(0), 0)
+T.eq("a numeric string", tofinite("12.5"), 12.5)
+
+T.section("tofinite rejects everything else")
+T.eq("NaN", tofinite(NAN), nil)
+T.eq("positive infinity", tofinite(math.huge), nil)
+T.eq("negative infinity", tofinite(-math.huge), nil)
+T.eq("a non-numeric string", tofinite("warm"), nil)
+T.eq("nil", tofinite(nil), nil)
+
+-- The reason the helper exists: this is what the idiom it replaces does.
+T.check("tonumber alone lets a NaN through", tonumber(NAN) ~= tonumber(NAN))
+T.eq("so the usual `or` fallback fires only with tofinite", tofinite(NAN) or 0, 0)
+
+-- ── tointeger ────────────────────────────────────────────────────────────────
+
+T.section("tointeger still rounds")
+T.eq("rounds up at the half", tointeger(2.5), 3)
+T.eq("rounds a negative away from zero", tointeger(-2.5), -3)
+T.eq("parses a string", tointeger("7"), 7)
+T.eq("rejects a non-numeric string", tointeger("warm"), nil)
+
+T.section("tointeger rejects non-finite input")
+T.eq("NaN is not an integer", tointeger(NAN), nil)
+T.eq("infinity is not an integer", tointeger(math.huge), nil)
+T.eq("negative infinity is not an integer", tointeger(-math.huge), nil)
+
+-- assertInt only checks for nil, so before the above it would have handed a
+-- caller a NaN while claiming to have narrowed the type.
+T.raises("assertInt rejects a NaN rather than narrowing it", function()
+  assertInt(NAN)
+end, "expected integer")
+
+-- ── SerializeSafe / DeserializeSafe ──────────────────────────────────────────
+
+T.section("a non-finite number survives a serialize round trip")
+local roundTrippedNan = DeserializeSafe(SerializeSafe(NAN))
+T.check("NaN comes back as NaN, not nil", roundTrippedNan ~= roundTrippedNan, roundTrippedNan)
+T.eq("positive infinity comes back", DeserializeSafe(SerializeSafe(math.huge)), math.huge)
+T.eq("negative infinity comes back", DeserializeSafe(SerializeSafe(-math.huge)), -math.huge)
+
+local nested = DeserializeSafe(SerializeSafe({ temperature = NAN, setpoint = 21.5, ceiling = math.huge }))
+T.check("a NaN nested in a table survives", nested.temperature ~= nested.temperature, nested.temperature)
+T.eq("its finite neighbour is untouched", nested.setpoint, 21.5)
+T.eq("an infinity nested in a table survives", nested.ceiling, math.huge)
+
+-- A NaN and an absent key are the two cases the sentinel exists to separate.
+local absent = DeserializeSafe(SerializeSafe({ setpoint = 21.5 }))
+T.eq("a key that was never set is still absent", absent.temperature, nil)
+
+T.section("the sentinel strings do not collide with real strings")
+for _, literal in ipairs({ "__nan__", "__inf__", "__-inf__", "__null__" }) do
+  local got = DeserializeSafe(SerializeSafe(literal))
+  T.eq(string.format("%q round trips as a string", literal), got, literal)
+end
+
+-- ── Values:update ────────────────────────────────────────────────────────────
+
+T.section("Values:update does not rewrite storage for an unchanged NaN")
+
+-- The module is a singleton instance, not the class.
+local values = require("lib.values")
+
+local writes = 0
+local realPersistSetValue = C4.PersistSetValue
+function C4:PersistSetValue(key, value, encrypted)
+  writes = writes + 1
+  return realPersistSetValue(self, key, value, encrypted)
+end
+
+T.check("the first NaN reading is a change", values:update("Temperature", NAN, "FLOAT") == true)
+
+local writesAfterFirst = writes
+local changedAgain = values:update("Temperature", NAN, "FLOAT")
+T.check("republishing the same NaN is not a change", changedAgain == false)
+T.eq("and it writes nothing to persistent storage", writes - writesAfterFirst, 0)
+
+-- The guard must not swallow a genuine transition in either direction.
+T.check("NaN to a real reading is a change", values:update("Temperature", 21.5, "FLOAT") == true)
+T.check("the same real reading is not", values:update("Temperature", 21.5, "FLOAT") == false)
+T.check("a real reading back to NaN is a change", values:update("Temperature", NAN, "FLOAT") == true)
+
+C4.PersistSetValue = realPersistSetValue
+
+T.finish()

--- a/test/test_sensor_params.lua
+++ b/test/test_sensor_params.lua
@@ -1,0 +1,150 @@
+-- Tests for the temperature/humidity binding payload helpers in src/lib/utils.lua.
+-- The key sets pinned here are an interop contract with drivers we do not own.
+-- Regression test for DRV-121.
+--
+-- Run from the driver root:
+--   make test
+-- or:
+--   ./test/run_test.sh test_sensor_params.lua
+
+local T = require("testlib")
+
+require("c4_shim")
+require("lib.utils")
+
+--------------------------------------------------------------------------------
+T.section("SensorValueParams emits every key a strict consumer reads")
+--------------------------------------------------------------------------------
+do
+  local before = os.time()
+  local params = SensorValueParams(21.5, "CELSIUS")
+  local after = os.time()
+
+  T.eq("VALUE stays in the reported scale", params.VALUE, 21.5)
+  T.eq("SCALE is passed through", params.SCALE, "CELSIUS")
+  T.eq("CELSIUS is the Celsius reading", params.CELSIUS, 21.5)
+  T.eq("FAHRENHEIT is converted", params.FAHRENHEIT, 70.7)
+  T.check(
+    "TIMESTAMP is epoch seconds from os.time()",
+    type(params.TIMESTAMP) == "number" and params.TIMESTAMP >= before and params.TIMESTAMP <= after,
+    params.TIMESTAMP
+  )
+end
+
+--------------------------------------------------------------------------------
+T.section("A Fahrenheit-native provider keeps its VALUE and gains Celsius")
+--------------------------------------------------------------------------------
+do
+  -- An ESPHome sensor converted to Fahrenheit in its config, or a Device
+  -- Programmer on a project set to Fahrenheit, measures in F. Rewriting VALUE
+  -- to Celsius would change what every existing consumer reads.
+  local params = SensorValueParams(70.7, "FAHRENHEIT")
+  T.eq("VALUE is left in Fahrenheit", params.VALUE, 70.7)
+  T.eq("SCALE still says Fahrenheit", params.SCALE, "FAHRENHEIT")
+  T.eq("CELSIUS is converted", params.CELSIUS, 21.5)
+  T.eq("FAHRENHEIT round-trips back to VALUE", params.FAHRENHEIT, 70.7)
+end
+
+do
+  local params = SensorValueParams(294.65, "KELVIN")
+  T.eq("Kelvin converts to Celsius", params.CELSIUS, 21.5)
+  T.eq("and on to Fahrenheit", params.FAHRENHEIT, 70.7)
+end
+
+--------------------------------------------------------------------------------
+T.section("A non-temperature scale gets TIMESTAMP but no temperature keys")
+--------------------------------------------------------------------------------
+do
+  local params = SensorValueParams(48, "PERCENT")
+  T.eq("VALUE is the percentage", params.VALUE, 48)
+  T.eq("SCALE is PERCENT", params.SCALE, "PERCENT")
+  T.eq("no CELSIUS on a humidity reading", params.CELSIUS, nil)
+  T.eq("no FAHRENHEIT on a humidity reading", params.FAHRENHEIT, nil)
+  T.check("humidity still carries TIMESTAMP", type(params.TIMESTAMP) == "number", params.TIMESTAMP)
+end
+
+do
+  -- esphome_bthome types its config scale as optional, so a sensor class
+  -- without one reaches here with nil.
+  local params = SensorValueParams(48, nil)
+  T.eq("a nil scale is passed through", params.SCALE, nil)
+  T.eq("and yields no CELSIUS", params.CELSIUS, nil)
+  T.check("but still carries TIMESTAMP", type(params.TIMESTAMP) == "number", params.TIMESTAMP)
+end
+
+--------------------------------------------------------------------------------
+T.section("CelsiusFromParams reads each provider convention")
+--------------------------------------------------------------------------------
+do
+  T.eq("CELSIUS is preferred", CelsiusFromParams({ CELSIUS = 21.5 }, "CELSIUS"), 21.5)
+  T.eq(
+    "CELSIUS wins over a disagreeing FAHRENHEIT",
+    CelsiusFromParams({ CELSIUS = 21.5, FAHRENHEIT = 200 }, "CELSIUS"),
+    21.5
+  )
+  T.eq("FAHRENHEIT is converted", CelsiusFromParams({ FAHRENHEIT = 70.7 }, "CELSIUS"), 21.5)
+  T.eq("VALUE is read per SCALE", CelsiusFromParams({ VALUE = 70.7, SCALE = "FAHRENHEIT" }, "CELSIUS"), 21.5)
+  T.eq("a Kelvin SCALE converts", CelsiusFromParams({ VALUE = 294.65, SCALE = "KELVIN" }, "CELSIUS"), 21.5)
+end
+
+do
+  -- The thermostat proxy sends letters; sensor bindings send whole words; and
+  -- esphome_climate has been reading a lowercase "c" since it was written.
+  T.eq("letter C", CelsiusFromParams({ VALUE = 21.5, SCALE = "C" }, "F"), 21.5)
+  T.eq("lowercase c", CelsiusFromParams({ VALUE = 21.5, SCALE = "c" }, "F"), 21.5)
+  T.eq("letter F", CelsiusFromParams({ VALUE = 70.7, SCALE = "F" }, "C"), 21.5)
+  T.eq("mixed case word", CelsiusFromParams({ VALUE = 70.7, SCALE = "Fahrenheit" }, "C"), 21.5)
+end
+
+--------------------------------------------------------------------------------
+T.section("A bare VALUE is read in the caller's default scale")
+--------------------------------------------------------------------------------
+do
+  -- The two call sites disagree on purpose: a TEMPERATURE_VALUE sensor binding
+  -- reports Celsius, while the thermostat proxy's SET_SETPOINT_* sends
+  -- Fahrenheit. A single shared default would silently mis-convert one of them.
+  T.eq("a sensor consumer reads Celsius", CelsiusFromParams({ VALUE = 21.5 }, "CELSIUS"), 21.5)
+  T.eq("a setpoint handler reads Fahrenheit", CelsiusFromParams({ VALUE = 70.7 }, "F"), 21.5)
+end
+
+--------------------------------------------------------------------------------
+T.section("Params arriving as strings still parse")
+--------------------------------------------------------------------------------
+do
+  -- SendToProxy params reach the far side as strings.
+  T.eq("string CELSIUS", CelsiusFromParams({ CELSIUS = "21.5" }, "CELSIUS"), 21.5)
+  T.eq("string FAHRENHEIT", CelsiusFromParams({ FAHRENHEIT = "70.7" }, "CELSIUS"), 21.5)
+  T.eq("string VALUE with SCALE", CelsiusFromParams({ VALUE = "70.7", SCALE = "FAHRENHEIT" }, "CELSIUS"), 21.5)
+  T.eq("a comma decimal separator", CelsiusFromParams({ CELSIUS = "21,5" }, "CELSIUS"), 21.5)
+end
+
+--------------------------------------------------------------------------------
+T.section("Nothing readable yields nil rather than a wrong number")
+--------------------------------------------------------------------------------
+do
+  T.eq("no params at all", CelsiusFromParams(nil, "CELSIUS"), nil)
+  T.eq("an empty table", CelsiusFromParams({}, "CELSIUS"), nil)
+  T.eq("only a SCALE", CelsiusFromParams({ SCALE = "CELSIUS" }, "CELSIUS"), nil)
+  T.eq("a non-numeric VALUE", CelsiusFromParams({ VALUE = "warm" }, "CELSIUS"), nil)
+  T.eq("a VALUE in a scale that is not a temperature", CelsiusFromParams({ VALUE = 48, SCALE = "PERCENT" }, "C"), nil)
+end
+
+--------------------------------------------------------------------------------
+T.section("Output and input are inverses, which is the interop property")
+--------------------------------------------------------------------------------
+do
+  -- What one of our drivers emits, another of our drivers must read back
+  -- unchanged, whichever scale the provider measured in.
+  local measured = { CELSIUS = 21.5, FAHRENHEIT = 70.7, KELVIN = 294.65 }
+  for scale, value in pairs(measured) do
+    local emitted = SensorValueParams(value, scale)
+    T.eq(scale .. " round-trips to the original Celsius", CelsiusFromParams(emitted, "CELSIUS"), 21.5)
+  end
+end
+
+do
+  -- The YoLink shape: the two temperature keys, no VALUE and no TIMESTAMP.
+  T.eq("a YoLink payload is ingestible", CelsiusFromParams({ CELSIUS = "21.5", FAHRENHEIT = "70.7" }, "CELSIUS"), 21.5)
+end
+
+T.finish()

--- a/vendor/bitn.lua
+++ b/vendor/bitn.lua
@@ -33,6 +33,31 @@ do
     -- Constants
     local MASK32 = 0xFFFFFFFF
 
+    -- string.pack/unpack are bound only if they answer in the 5.3 dialect. Control4's
+    -- LuaJIT ships lpack under the same names: no size suffixes, and unpack takes
+    -- (data, fmt, pos) and returns the position first, so existence proves nothing.
+    local function probe_string_pack()
+      local pack, unpack = rawget(string, "pack"), rawget(string, "unpack")
+      if not (pack and unpack) then
+        return nil, nil
+      end
+      local packed_ok, packed = pcall(pack, "<I4", 0x04030201)
+      if not packed_ok or packed ~= "\1\2\3\4" then
+        return nil, nil
+      end
+      packed_ok, packed = pcall(pack, ">I4", 0x04030201)
+      if not packed_ok or packed ~= "\4\3\2\1" then
+        return nil, nil
+      end
+      local unpacked_ok, value, next_pos = pcall(unpack, "<I4", "\0\1\2\3\4", 2)
+      if not unpacked_ok or value ~= 0x04030201 or next_pos ~= 6 then
+        return nil, nil
+      end
+      return pack, unpack
+    end
+
+    _compat.string_pack, _compat.string_unpack = probe_string_pack()
+
     --------------------------------------------------------------------------------
     -- Implementation 1: Native operators (Lua 5.3+)
     --------------------------------------------------------------------------------
@@ -1181,8 +1206,8 @@ do
 
     local string_char = string.char
     local string_byte = string.byte
-    local string_pack = rawget(string, "pack")
-    local string_unpack = rawget(string, "unpack")
+    local string_pack = _compat.string_pack
+    local string_unpack = _compat.string_unpack
     -- % is the whole operation on the pure Lua backend; skip the call.
     local fast_band = _compat.has_native_ops or _compat.has_bit_lib
 
@@ -1909,8 +1934,8 @@ do
     local impl_name = _compat.impl_name
     local math_floor = math.floor
     local string_char = string.char
-    local string_pack = rawget(string, "pack")
-    local string_unpack = rawget(string, "unpack")
+    local string_pack = _compat.string_pack
+    local string_unpack = _compat.string_unpack
 
     -- Private metatable for Int64 type identification
     local Int64Meta = { __name = "Int64" }
@@ -3578,7 +3603,7 @@ local bitn = {
 }
 
 --- Library version (injected at build time for releases).
-local VERSION = "v0.6.3"
+local VERSION = "v0.6.4"
 
 --- Get the library version string.
 --- @return string version Version string (e.g., "v1.0.0" or "dev")

--- a/vendor/bthome.lua
+++ b/vendor/bthome.lua
@@ -912,12 +912,18 @@ do
     --- @class bthome.crypto.aes_ccm
     local aes_ccm = {}
 
-    local bit32 = require("bitn").bit32
+    local bitn = require("bitn")
+    local bit16 = bitn.bit16
+    local bit32 = bitn.bit32
+    local bit64 = bitn.bit64
 
     -- Local references for performance
+    local bit16_u16_to_be_bytes = bit16.u16_to_be_bytes
     local bit32_raw_band = bit32.raw_band
     local bit32_raw_bxor = bit32.raw_bxor
     local bit32_raw_lshift = bit32.raw_lshift
+    local bit64_from_number = bit64.from_number
+    local bit64_u64_to_be_bytes = bit64.u64_to_be_bytes
     local math_floor = math.floor
     local math_min = math.min
     local string_byte = string.byte
@@ -1449,6 +1455,14 @@ do
       return table_concat(result)
     end
 
+    --- Big-endian encoding of n in exactly L bytes (L <= 8).
+    --- @param n integer Value to encode
+    --- @param L integer Field width in bytes
+    --- @return string bytes
+    local function be_bytes(n, L)
+      return string_sub(bit64_u64_to_be_bytes(bit64_from_number(n)), 9 - L)
+    end
+
     --- Generate CTR counter blocks.
     --- @param nonce string CCM nonce
     --- @param counter integer Counter value (0 for CBC-MAC tag encryption, 1+ for CTR)
@@ -1459,18 +1473,7 @@ do
       -- Flags = L-1 (for CTR blocks)
       local flags = math_floor(L - 1)
 
-      -- Build counter block
-      local block = string_char(flags) .. nonce
-
-      -- Append counter (big-endian, L bytes)
-      local counter_bytes = {}
-      local temp_counter = counter
-      for i = L, 1, -1 do
-        counter_bytes[i] = string_char(math_floor(temp_counter % 256))
-        temp_counter = math_floor(temp_counter / 256)
-      end
-
-      return block .. table_concat(counter_bytes)
+      return string_char(flags) .. nonce .. be_bytes(counter, L)
     end
 
     --- Compute CBC-MAC authentication tag.
@@ -1495,14 +1498,7 @@ do
       -- B0 = Flags || Nonce || Q (message length, L bytes, big-endian)
       local b0 = string_char(flags) .. nonce
 
-      -- Append message length (L bytes, big-endian)
-      local msg_len = #plaintext
-      local len_bytes = {}
-      for i = L, 1, -1 do
-        len_bytes[i] = string_char(math_floor(msg_len % 256))
-        msg_len = math_floor(msg_len / 256)
-      end
-      b0 = b0 .. table_concat(len_bytes)
+      b0 = b0 .. be_bytes(#plaintext, L)
 
       -- Initialize CBC-MAC with B0
       local y = aes_encrypt_block(b0, expanded_key, nr)
@@ -1512,7 +1508,7 @@ do
         local aad_block
         if #aad < 0xFF00 then
           -- Short encoding: 2-byte length prefix
-          aad_block = string_char(math_floor(#aad / 256), math_floor(#aad % 256)) .. aad
+          aad_block = bit16_u16_to_be_bytes(#aad) .. aad
         else
           error("AAD too long")
         end
@@ -1855,6 +1851,10 @@ do
     --- @class bthome.event
     local event = {}
 
+    local bit16 = require("bitn").bit16
+    local bit16_band = bit16.band
+    local bit16_rshift = bit16.rshift
+
     --- @class BTHomeButtonEvent
     --- @field raw_value integer Raw event byte value
     --- @field event_type integer Event type code
@@ -1955,9 +1955,8 @@ do
     --- @param value integer The raw 2-byte dimmer value (as little-endian uint16)
     --- @return BTHomeDimmerEvent result Decoded dimmer event with event_type and steps
     function event.decode_dimmer(value)
-      -- Value is read as little-endian uint16: low byte = event_type, high byte = steps
-      local event_type = value % 256
-      local steps = math.floor(value / 256)
+      local event_type = bit16_band(value, 0xFF)
+      local steps = bit16_rshift(value, 8)
 
       return {
         raw_value = value,
@@ -2069,6 +2068,10 @@ do
     --- @class bthome.parser
     local parser = {}
 
+    local bitn = require("bitn")
+    local bit16_u16_to_le_bytes = bitn.bit16.u16_to_le_bytes
+    local bit32_u32_to_le_bytes = bitn.bit32.u32_to_le_bytes
+
     --- BTHome V1 unencrypted service UUID.
     --- @type integer
     parser.UUID_V1_UNENCRYPTED = 0x181C
@@ -2137,14 +2140,7 @@ do
     --- @param counter integer 32-bit counter
     --- @return string nonce 12-byte nonce
     local function build_v1_nonce(mac, uuid, counter)
-      return mac
-        .. string.char(uuid % 256, math.floor(uuid / 256))
-        .. string.char(
-          counter % 256,
-          math.floor(counter / 256) % 256,
-          math.floor(counter / 65536) % 256,
-          math.floor(counter / 16777216) % 256
-        )
+      return mac .. bit16_u16_to_le_bytes(uuid) .. bit32_u32_to_le_bytes(counter)
     end
 
     --- Build nonce for BTHome V2 encrypted advertisements.
@@ -2155,15 +2151,7 @@ do
     --- @param counter integer 32-bit counter
     --- @return string nonce 13-byte nonce
     local function build_v2_nonce(mac, uuid, device_info, counter)
-      return mac
-        .. string.char(uuid % 256, math.floor(uuid / 256))
-        .. string.char(device_info)
-        .. string.char(
-          counter % 256,
-          math.floor(counter / 256) % 256,
-          math.floor(counter / 65536) % 256,
-          math.floor(counter / 16777216) % 256
-        )
+      return mac .. bit16_u16_to_le_bytes(uuid) .. string.char(device_info) .. bit32_u32_to_le_bytes(counter)
     end
 
     --- Parse the device info byte to extract flags and version.
@@ -3423,7 +3411,7 @@ bthome.UUID_V1_ENCRYPTED = bthome.parser.UUID_V1_ENCRYPTED
 bthome.UUID_V2 = bthome.parser.UUID_V2
 
 --- Library version (injected at build time for releases).
-local VERSION = "v0.1.5"
+local VERSION = "v0.1.7"
 
 --- Get the library version string.
 --- @return string version Version string (e.g., "v1.0.0" or "dev")

--- a/vendor/crypto.lua
+++ b/vendor/crypto.lua
@@ -629,22 +629,7 @@ do
     --- @param counter string 16-byte counter block
     --- @return string result Incremented counter
     local function inc_counter(counter)
-      local result = string_sub(counter, 1, 12) -- Keep first 12 bytes
-
-      -- Increment last 4 bytes (big-endian)
-      local val = 0
-      for i = 13, 16 do
-        val = val * 256 + string_byte(counter, i)
-      end
-
-      val = (val + 1) % 0x100000000
-
-      -- Convert back to bytes (big-endian)
-      for i = 3, 0, -1 do
-        result = result .. string_char(bit32_raw_band(bit32_raw_rshift(val, i * 8), 0xFF))
-      end
-
-      return result
+      return string_sub(counter, 1, 12) .. bytes.u32_to_be_bytes(bytes.be_bytes_to_u32(counter, 13) + 1)
     end
 
     --- Generate counter mode keystream
@@ -3839,7 +3824,8 @@ do
     local bit32_raw_add = bit32.raw_add
     local bit32_raw_bxor = bit32.raw_bxor
     local bit32_raw_rol = bit32.raw_rol
-    local floor = math.floor
+    local bit32_u32_to_le_bytes = bit32.u32_to_le_bytes
+    local bit32_le_bytes_to_u32 = bit32.le_bytes_to_u32
     local min = math.min
     local string_byte = string.byte
     local string_char = string.char
@@ -3881,31 +3867,6 @@ do
     -- Pre-allocated arrays for chacha20_block() to avoid repeated allocation
     local block_state = create_word_array()
     local block_working = create_word_array()
-
-    --- Convert 32-bit word to 4 bytes (little-endian)
-    --- @param word integer 32-bit word
-    --- @return integer, integer, integer, integer bytes Four bytes in little-endian order
-    local function word_to_bytes(word)
-      local byte1 = word % 256
-      word = floor(word * 0.00390625) -- / 256
-      local byte2 = word % 256
-      word = floor(word * 0.00390625)
-      local byte3 = word % 256
-      word = floor(word * 0.00390625)
-      local byte4 = word % 256
-
-      return byte1, byte2, byte3, byte4
-    end
-
-    --- Convert 4 bytes to 32-bit word (little-endian)
-    --- @param byte1 integer First byte (least significant)
-    --- @param byte2 integer Second byte
-    --- @param byte3 integer Third byte
-    --- @param byte4 integer Fourth byte (most significant)
-    --- @return integer word 32-bit word
-    local function bytes_to_word(byte1, byte2, byte3, byte4)
-      return byte1 + byte2 * 256 + byte3 * 65536 + byte4 * 16777216
-    end
 
     --- ChaCha20 quarter round operation
     --- @param state Word32Array 16-word state array (modified in place)
@@ -3950,13 +3911,7 @@ do
 
       -- 256-bit key (8 words)
       for i = 1, 8 do
-        local base = (i - 1) * 4
-        state[4 + i] = bytes_to_word(
-          string_byte(key, base + 1),
-          string_byte(key, base + 2),
-          string_byte(key, base + 3),
-          string_byte(key, base + 4)
-        )
+        state[4 + i] = bit32_le_bytes_to_u32(key, (i - 1) * 4 + 1)
       end
 
       -- 32-bit counter
@@ -3964,13 +3919,7 @@ do
 
       -- 96-bit nonce (3 words)
       for i = 1, 3 do
-        local base = (i - 1) * 4
-        state[13 + i] = bytes_to_word(
-          string_byte(nonce, base + 1),
-          string_byte(nonce, base + 2),
-          string_byte(nonce, base + 3),
-          string_byte(nonce, base + 4)
-        )
+        state[13 + i] = bit32_le_bytes_to_u32(nonce, (i - 1) * 4 + 1)
       end
 
       -- Create working copy of state
@@ -3998,11 +3947,9 @@ do
         working_state[i] = bit32_raw_add(working_state[i], state[i])
       end
 
-      -- Convert state to byte string (little-endian) - optimized with local references
       local result_bytes = {}
       for i = 1, 16 do
-        local b1, b2, b3, b4 = word_to_bytes(working_state[i])
-        result_bytes[i] = string_char(b1, b2, b3, b4)
+        result_bytes[i] = bit32_u32_to_le_bytes(working_state[i])
       end
 
       return table_concat(result_bytes)
@@ -8992,12 +8939,12 @@ do
     local bit64_raw_ror = bit64.raw_ror
     local bit64_raw_rshift = bit64.raw_rshift
     local bit64_new = bit64.new
+    local bit64_from_number = bit64.from_number
     local bit32_raw_bxor = bit32.raw_bxor
     local string_char = string.char
     local string_rep = string.rep
     local string_byte = string.byte
     local table_concat = table.concat
-    local floor = math.floor
 
     -- SHA-512 uses 64-bit words, but Lua numbers are limited to 2^53-1
     -- We'll work with 32-bit high/low pairs for 64-bit arithmetic
@@ -9252,10 +9199,7 @@ do
       -- Append original length as 128-bit big-endian integer
       -- For simplicity, we only support messages < 2^64 bits
       data = data .. string_rep("\0", 8) -- High 64 bits (always 0)
-      -- Low 64 bits of length
-      local len_high = floor(msg_len_bits / 0x100000000)
-      local len_low = msg_len_bits % 0x100000000
-      data = data .. bytes.u64_to_be_bytes({ len_high, len_low })
+      data = data .. bytes.u64_to_be_bytes(bit64_from_number(msg_len_bits))
 
       -- Process message in 128-byte chunks
       for i = 1, #data, 128 do
@@ -10502,10 +10446,18 @@ do
     local bit64 = bitn.bit64
 
     -- Local references for performance
-    local bit32_mask = bit32.mask
     local bit32_raw_bor = bit32.raw_bor
     local bit32_raw_bxor = bit32.raw_bxor
+    local bit32_u32_to_le_bytes = bit32.u32_to_le_bytes
+    local bit32_u32_to_be_bytes = bit32.u32_to_be_bytes
+    local bit32_le_bytes_to_u32 = bit32.le_bytes_to_u32
+    local bit32_be_bytes_to_u32 = bit32.be_bytes_to_u32
     local bit64_new = bit64.new
+    local bit64_from_number = bit64.from_number
+    local bit64_u64_to_le_bytes = bit64.u64_to_le_bytes
+    local bit64_u64_to_be_bytes = bit64.u64_to_be_bytes
+    local bit64_le_bytes_to_u64 = bit64.le_bytes_to_u64
+    local bit64_be_bytes_to_u64 = bit64.be_bytes_to_u64
     local floor = math.floor
     local string_byte = string.byte
     local string_char = string.char
@@ -10535,40 +10487,32 @@ do
     --- @param n integer 32-bit unsigned integer
     --- @return string bytes 4-byte string in little-endian order
     function bytes.u32_to_le_bytes(n)
-      n = bit32_mask(n)
-      return string_char(n % 256, floor(n / 256) % 256, floor(n / 65536) % 256, floor(n / 16777216) % 256)
+      return bit32_u32_to_le_bytes(n)
     end
 
     --- Convert 32-bit unsigned integer to 4 bytes (big-endian)
     --- @param n integer 32-bit unsigned integer
     --- @return string bytes 4-byte string in big-endian order
     function bytes.u32_to_be_bytes(n)
-      n = bit32_mask(n)
-      return string_char(floor(n / 16777216) % 256, floor(n / 65536) % 256, floor(n / 256) % 256, n % 256)
+      return bit32_u32_to_be_bytes(n)
     end
 
     --- Convert 64-bit value to 8 bytes (big-endian)
     --- @param x Int64HighLow {high, low} 64-bit value
     --- @return string bytes 8-byte string in big-endian order
     function bytes.u64_to_be_bytes(x)
-      local high, low = x[1], x[2]
-      return bytes.u32_to_be_bytes(high) .. bytes.u32_to_be_bytes(low)
+      return bit64_u64_to_be_bytes(x)
     end
 
     --- Convert 64-bit value to 8 bytes (little-endian)
     --- @param x Int64HighLow|integer {high, low} 64-bit value or simple integer
     --- @return string bytes 8-byte string in little-endian order
     function bytes.u64_to_le_bytes(x)
-      -- Handle simple integer case (< 2^53)
       if type(x) == "number" then
-        local low = x % 0x100000000
-        local high = floor(x / 0x100000000)
-        return bytes.u32_to_le_bytes(low) .. bytes.u32_to_le_bytes(high)
-      else
-        -- Handle {high, low} pair
-        local high, low = x[1], x[2]
-        return bytes.u32_to_le_bytes(low) .. bytes.u32_to_le_bytes(high)
+        return bit64_u64_to_le_bytes(bit64_from_number(x))
       end
+      --- @cast x Int64HighLow
+      return bit64_u64_to_le_bytes(x)
     end
 
     --- Convert 4 bytes to 32-bit unsigned integer (little-endian)
@@ -10576,10 +10520,7 @@ do
     --- @param offset? integer Starting position (default: 1)
     --- @return integer n 32-bit unsigned integer
     function bytes.le_bytes_to_u32(str, offset)
-      offset = offset or 1
-      assert(#str >= offset + 3, "Insufficient bytes for u32")
-      local b1, b2, b3, b4 = string_byte(str, offset, offset + 3)
-      return b1 + b2 * 256 + b3 * 65536 + b4 * 16777216
+      return bit32_le_bytes_to_u32(str, offset)
     end
 
     --- Convert 4 bytes to 32-bit unsigned integer (big-endian)
@@ -10587,10 +10528,7 @@ do
     --- @param offset? integer Starting position (default: 1)
     --- @return integer n 32-bit unsigned integer
     function bytes.be_bytes_to_u32(str, offset)
-      offset = offset or 1
-      assert(#str >= offset + 3, "Insufficient bytes for u32")
-      local b1, b2, b3, b4 = string_byte(str, offset, offset + 3)
-      return b1 * 16777216 + b2 * 65536 + b3 * 256 + b4
+      return bit32_be_bytes_to_u32(str, offset)
     end
 
     --- Convert 8 bytes to 64-bit value (big-endian)
@@ -10598,11 +10536,7 @@ do
     --- @param offset? integer Starting position (default: 1)
     --- @return Int64HighLow value {high, low} 64-bit value
     function bytes.be_bytes_to_u64(str, offset)
-      offset = offset or 1
-      assert(#str >= offset + 7, "Insufficient bytes for u64")
-      local high = bytes.be_bytes_to_u32(str, offset)
-      local low = bytes.be_bytes_to_u32(str, offset + 4)
-      return { high, low }
+      return bit64_be_bytes_to_u64(str, offset)
     end
 
     --- Convert 8 bytes to 64-bit value (little-endian)
@@ -10610,11 +10544,7 @@ do
     --- @param offset? integer Starting position (default: 1)
     --- @return Int64HighLow value {high, low} 64-bit value
     function bytes.le_bytes_to_u64(str, offset)
-      offset = offset or 1
-      assert(#str >= offset + 7, "Insufficient bytes for u64")
-      local low = bytes.le_bytes_to_u32(str, offset)
-      local high = bytes.le_bytes_to_u32(str, offset + 4)
-      return { high, low }
+      return bit64_le_bytes_to_u64(str, offset)
     end
 
     --- XOR two byte strings
@@ -12520,7 +12450,7 @@ local crypto = {
 local openssl_wrapper = crypto.openssl_wrapper
 
 --- Library version (injected at build time for releases).
-local VERSION = "v0.2.2"
+local VERSION = "v0.2.4"
 
 --- Enable or disable OpenSSL acceleration for the primitives that support it
 --- (hashing and AEAD). Opt-in and safe: when the lua-openssl binding is

--- a/vendor/noiseprotocol.lua
+++ b/vendor/noiseprotocol.lua
@@ -71,10 +71,18 @@ do
     local bit64 = bitn.bit64
 
     -- Local references for performance
-    local bit32_mask = bit32.mask
     local bit32_raw_bor = bit32.raw_bor
     local bit32_raw_bxor = bit32.raw_bxor
+    local bit32_u32_to_le_bytes = bit32.u32_to_le_bytes
+    local bit32_u32_to_be_bytes = bit32.u32_to_be_bytes
+    local bit32_le_bytes_to_u32 = bit32.le_bytes_to_u32
+    local bit32_be_bytes_to_u32 = bit32.be_bytes_to_u32
     local bit64_new = bit64.new
+    local bit64_from_number = bit64.from_number
+    local bit64_u64_to_le_bytes = bit64.u64_to_le_bytes
+    local bit64_u64_to_be_bytes = bit64.u64_to_be_bytes
+    local bit64_le_bytes_to_u64 = bit64.le_bytes_to_u64
+    local bit64_be_bytes_to_u64 = bit64.be_bytes_to_u64
     local floor = math.floor
     local string_byte = string.byte
     local string_char = string.char
@@ -104,40 +112,32 @@ do
     --- @param n integer 32-bit unsigned integer
     --- @return string bytes 4-byte string in little-endian order
     function bytes.u32_to_le_bytes(n)
-      n = bit32_mask(n)
-      return string_char(n % 256, floor(n / 256) % 256, floor(n / 65536) % 256, floor(n / 16777216) % 256)
+      return bit32_u32_to_le_bytes(n)
     end
 
     --- Convert 32-bit unsigned integer to 4 bytes (big-endian)
     --- @param n integer 32-bit unsigned integer
     --- @return string bytes 4-byte string in big-endian order
     function bytes.u32_to_be_bytes(n)
-      n = bit32_mask(n)
-      return string_char(floor(n / 16777216) % 256, floor(n / 65536) % 256, floor(n / 256) % 256, n % 256)
+      return bit32_u32_to_be_bytes(n)
     end
 
     --- Convert 64-bit value to 8 bytes (big-endian)
     --- @param x Int64HighLow {high, low} 64-bit value
     --- @return string bytes 8-byte string in big-endian order
     function bytes.u64_to_be_bytes(x)
-      local high, low = x[1], x[2]
-      return bytes.u32_to_be_bytes(high) .. bytes.u32_to_be_bytes(low)
+      return bit64_u64_to_be_bytes(x)
     end
 
     --- Convert 64-bit value to 8 bytes (little-endian)
     --- @param x Int64HighLow|integer {high, low} 64-bit value or simple integer
     --- @return string bytes 8-byte string in little-endian order
     function bytes.u64_to_le_bytes(x)
-      -- Handle simple integer case (< 2^53)
       if type(x) == "number" then
-        local low = x % 0x100000000
-        local high = floor(x / 0x100000000)
-        return bytes.u32_to_le_bytes(low) .. bytes.u32_to_le_bytes(high)
-      else
-        -- Handle {high, low} pair
-        local high, low = x[1], x[2]
-        return bytes.u32_to_le_bytes(low) .. bytes.u32_to_le_bytes(high)
+        return bit64_u64_to_le_bytes(bit64_from_number(x))
       end
+      --- @cast x Int64HighLow
+      return bit64_u64_to_le_bytes(x)
     end
 
     --- Convert 4 bytes to 32-bit unsigned integer (little-endian)
@@ -145,10 +145,7 @@ do
     --- @param offset? integer Starting position (default: 1)
     --- @return integer n 32-bit unsigned integer
     function bytes.le_bytes_to_u32(str, offset)
-      offset = offset or 1
-      assert(#str >= offset + 3, "Insufficient bytes for u32")
-      local b1, b2, b3, b4 = string_byte(str, offset, offset + 3)
-      return b1 + b2 * 256 + b3 * 65536 + b4 * 16777216
+      return bit32_le_bytes_to_u32(str, offset)
     end
 
     --- Convert 4 bytes to 32-bit unsigned integer (big-endian)
@@ -156,10 +153,7 @@ do
     --- @param offset? integer Starting position (default: 1)
     --- @return integer n 32-bit unsigned integer
     function bytes.be_bytes_to_u32(str, offset)
-      offset = offset or 1
-      assert(#str >= offset + 3, "Insufficient bytes for u32")
-      local b1, b2, b3, b4 = string_byte(str, offset, offset + 3)
-      return b1 * 16777216 + b2 * 65536 + b3 * 256 + b4
+      return bit32_be_bytes_to_u32(str, offset)
     end
 
     --- Convert 8 bytes to 64-bit value (big-endian)
@@ -167,11 +161,7 @@ do
     --- @param offset? integer Starting position (default: 1)
     --- @return Int64HighLow value {high, low} 64-bit value
     function bytes.be_bytes_to_u64(str, offset)
-      offset = offset or 1
-      assert(#str >= offset + 7, "Insufficient bytes for u64")
-      local high = bytes.be_bytes_to_u32(str, offset)
-      local low = bytes.be_bytes_to_u32(str, offset + 4)
-      return { high, low }
+      return bit64_be_bytes_to_u64(str, offset)
     end
 
     --- Convert 8 bytes to 64-bit value (little-endian)
@@ -179,11 +169,7 @@ do
     --- @param offset? integer Starting position (default: 1)
     --- @return Int64HighLow value {high, low} 64-bit value
     function bytes.le_bytes_to_u64(str, offset)
-      offset = offset or 1
-      assert(#str >= offset + 7, "Insufficient bytes for u64")
-      local low = bytes.le_bytes_to_u32(str, offset)
-      local high = bytes.le_bytes_to_u32(str, offset + 4)
-      return { high, low }
+      return bit64_le_bytes_to_u64(str, offset)
     end
 
     --- XOR two byte strings
@@ -770,9 +756,14 @@ local noiseprotocol = {}
 local crypto = require("crypto")
 local utils = require("noiseprotocol.utils")
 local openssl_wrapper = require("crypto.openssl_wrapper")
+local bit64 = require("bitn").bit64
+
+local bit64_from_number = bit64.from_number
+local bit64_u64_to_le_bytes = bit64.u64_to_le_bytes
+local bit64_u64_to_be_bytes = bit64.u64_to_be_bytes
 
 --- Module version
-local VERSION = "v0.6.4"
+local VERSION = "v0.6.6"
 
 --- Enable or disable OpenSSL acceleration
 --- @function use_openssl
@@ -964,14 +955,7 @@ local DH_448 = {
 local function make_chachapoly_nonce(n)
   -- ChaCha20Poly1305 uses little-endian format: 4 zero bytes + 64-bit counter
   assert(n <= MAX_NONCE, "Nonce overflow")
-  local nonce = string.rep("\0", 4) -- 4 zero bytes padding
-  -- Little-endian 64-bit counter (8 bytes)
-  for _ = 1, 8 do
-    nonce = nonce .. string.char(n % 256)
-    n = math.floor(n / 256)
-  end
-
-  return nonce
+  return string.rep("\0", 4) .. bit64_u64_to_le_bytes(bit64_from_number(n))
 end
 
 --- ChaCha20-Poly1305 AEAD implementation
@@ -997,20 +981,7 @@ local CIPHER_ChaChaPoly = {
 local function make_aesgcm_nonce(n)
   -- AESGCM uses big-endian format: 4 zero bytes + 64-bit counter
   assert(n <= MAX_NONCE, "Nonce overflow")
-  local nonce = string.rep("\0", 4) -- 4 zero bytes padding
-
-  -- Big-endian 64-bit counter
-  local bytes = {}
-  for i = 1, 8 do
-    bytes[i] = string.char(n % 256)
-    n = math.floor(n / 256)
-  end
-  -- Reverse the bytes for big-endian
-  for i = 8, 1, -1 do
-    nonce = nonce .. bytes[i]
-  end
-
-  return nonce
+  return string.rep("\0", 4) .. bit64_u64_to_be_bytes(bit64_from_number(n))
 end
 
 --- AES-GCM AEAD implementation

--- a/vendor/protobuf.lua
+++ b/vendor/protobuf.lua
@@ -9,17 +9,21 @@ local bit32 = bitn.bit32
 local bit64 = bitn.bit64
 
 -- Cache methods as locals for faster access
+local bit32_le_bytes_to_u32 = bit32.le_bytes_to_u32
 local bit32_raw_arshift = bit32.raw_arshift
 local bit32_raw_band = bit32.raw_band
 local bit32_raw_bor = bit32.raw_bor
 local bit32_raw_bxor = bit32.raw_bxor
 local bit32_raw_lshift = bit32.raw_lshift
 local bit32_raw_rshift = bit32.raw_rshift
+local bit32_to_signed = bit32.to_signed
 local bit32_to_unsigned = bit32.to_unsigned
+local bit32_u32_to_le_bytes = bit32.u32_to_le_bytes
 local bit64_eq = bit64.eq
 local bit64_from_number = bit64.from_number
 local bit64_is_int64 = bit64.is_int64
 local bit64_is_zero = bit64.is_zero
+local bit64_le_bytes_to_u64 = bit64.le_bytes_to_u64
 local bit64_new = bit64.new
 local bit64_raw_arshift = bit64.raw_arshift
 local bit64_raw_bor = bit64.raw_bor
@@ -28,19 +32,84 @@ local bit64_raw_lshift = bit64.raw_lshift
 local bit64_raw_rshift = bit64.raw_rshift
 local bit64_to_hex = bit64.to_hex
 local bit64_to_number = bit64.to_number
+local bit64_u64_to_le_bytes = bit64.u64_to_le_bytes
 
 -- Lua 5.3+ removed math.frexp and math.ldexp; provide polyfills
 local math_frexp = math.frexp
   or function(x)
-    if x == 0 then
-      return 0, 0
+    if x == 0 or x ~= x or x == math.huge or x == -math.huge then
+      return x, 0
     end
     local e = math.floor(math.log(math.abs(x)) / math.log(2)) + 1
-    return x / 2 ^ e, e
+    -- Scaling by a power of two is exact, but only while that power is itself a
+    -- normal double. 2 ^ -e is infinity by e = -1024 and subnormal by e = 1023,
+    -- and LuaJIT 2.0 returns zero for the subnormal end rather than the exact
+    -- value. Split the scale so neither factor ever leaves the normal range.
+    local m
+    if e > 1000 then
+      m = x * 2 ^ -1000 * 2 ^ (1000 - e)
+    elseif e < -1000 then
+      m = x * 2 ^ 1000 * 2 ^ (-e - 1000)
+    else
+      m = x * 2 ^ -e
+    end
+    -- The log quotient lands on the wrong side of an integer for some inputs,
+    -- which puts m outside [0.5, 1). Left uncorrected it reaches exactly 1.0 and
+    -- overflows the mantissa field downstream.
+    while m ~= 0 and (m >= 1 or m <= -1) do
+      m = m / 2
+      e = e + 1
+    end
+    while m ~= 0 and m > -0.5 and m < 0.5 do
+      m = m * 2
+      e = e - 1
+    end
+    return m, e
   end
-local math_ldexp = math.ldexp or function(m, e)
-  return m * 2 ^ e
+local math_ldexp = math.ldexp
+  or function(m, e)
+    -- Same constraint as the frexp fallback above: 2 ^ e is only exact while it
+    -- is itself a normal double, and LuaJIT 2.0 returns zero at the subnormal
+    -- end. Step the scale in normal-range chunks so a representable result is
+    -- never reached through an intermediate infinity or zero.
+    while e > 1000 do
+      m = m * 2 ^ 1000
+      e = e - 1000
+    end
+    while e < -1000 do
+      m = m * 2 ^ -1000
+      e = e + 1000
+    end
+    return m * 2 ^ e
+  end
+
+--- Rounds to the nearest integer with ties to even, which is the IEEE 754 default and
+--- the rule the hardware applies when it narrows a double to a float.
+--- @param x number A non-negative value below 2 ^ 53, so `x - floor(x)` is exact.
+--- @return number rounded
+local function round_half_even(x)
+  local lower = math.floor(x)
+  local fraction = x - lower
+  if fraction > 0.5 then
+    return lower + 1
+  elseif fraction < 0.5 then
+    return lower
+  elseif lower % 2 == 0 then
+    return lower
+  end
+  return lower + 1
 end
+
+-- The smallest normal at each width. Below these an IEEE value is subnormal: no
+-- implicit leading one, and an exponent pinned at the minimum instead of scaling.
+local FLOAT_MIN_NORMAL = 2 ^ -126
+local DOUBLE_MIN_NORMAL = 2 ^ -1022
+
+local NAN = 0 / 0
+local INF = math.huge
+-- Lua 5.1 constant-folds the literal -0.0 to +0.0, and LuaJIT does the same to
+-- 0.0 * -1. Dividing into an infinity is the one form that survives everywhere.
+local NEG_ZERO = -1 / INF
 
 --- Check if a value is a list (sequential table).
 --- @param t any The value to check.
@@ -62,7 +131,7 @@ local function is_list(t)
 end
 
 -- Version
-local VERSION = "v0.6.7"
+local VERSION = "v0.6.9"
 
 --- Returns the library version.
 --- @return string version The version string.
@@ -86,14 +155,14 @@ function pb.encode_varint(value)
 
     repeat
       -- Extract low 7 bits
-      local byte = v[2] % 128
+      local byte = bit32_raw_band(v[2], 0x7F)
 
       -- Right shift by 7 bits using bit64
       v = bit64_raw_rshift(v, 7)
 
       -- Set continue bit if more bytes remain
       if v[1] ~= 0 or v[2] ~= 0 then
-        byte = byte + 0x80
+        byte = bit32_raw_bor(byte, 0x80)
       end
       table.insert(bytes, string.char(byte))
     until v[1] == 0 and v[2] == 0
@@ -117,16 +186,14 @@ function pb.encode_varint(value)
   end
 
   -- For large values (> 32 bits), convert to {high, low} and use bit64
-  local low_32 = value % 0x100000000
-  local high_32 = math.floor(value / 0x100000000)
-  local v = bit64_new(high_32, low_32)
+  local v = bit64_from_number(value)
   local bytes = {}
 
   repeat
-    local byte = v[2] % 128
+    local byte = bit32_raw_band(v[2], 0x7F)
     v = bit64_raw_rshift(v, 7)
     if v[1] ~= 0 or v[2] ~= 0 then
-      byte = byte + 0x80
+      byte = bit32_raw_bor(byte, 0x80)
     end
     table.insert(bytes, string.char(byte))
   until v[1] == 0 and v[2] == 0
@@ -180,11 +247,10 @@ end
 --- @param value integer The 32-bit integer to encode.
 --- @return string bytes The encoded 4-byte sequence.
 function pb.encode_fixed32(value)
-  local b1 = value % 256
-  local b2 = math.floor(value / 256) % 256
-  local b3 = math.floor(value / 65536) % 256
-  local b4 = math.floor(value / 16777216)
-  return string.char(b1, b2, b3, b4)
+  if value < -0x80000000 or value > 0xFFFFFFFF then
+    error("fixed32 value out of range: " .. tostring(value), 2)
+  end
+  return bit32_u32_to_le_bytes(value)
 end
 
 --- Decodes a fixed-length 4-byte sequence into a 32-bit integer.
@@ -193,34 +259,14 @@ end
 --- @return integer value The decoded 32-bit integer value.
 --- @return integer new_pos The new position in the buffer after decoding.
 function pb.decode_fixed32(buffer, pos)
-  local b1, b2, b3, b4 = string.byte(buffer, pos, pos + 3)
-  local value = b1 + b2 * 256 + b3 * 65536 + b4 * 16777216
-  --- @cast value integer
-  return value, pos + 4
+  return bit32_le_bytes_to_u32(buffer, pos), pos + 4
 end
 
 --- Encodes a 64-bit integer into a fixed-length 8-byte sequence.
 --- @param value Int64HighLow|number The 64-bit integer as {high, low} or number.
 --- @return string bytes The encoded 8-byte sequence.
 function pb.encode_fixed64(value)
-  local high, low
-  if bit64_is_int64(value) then
-    --- @cast value Int64HighLow
-    high, low = value[1], value[2]
-  else
-    --- @cast value -Int64HighLow
-    low = math.floor(value % 0x100000000)
-    high = math.floor(value / 0x100000000)
-  end
-  local b1 = low % 256
-  local b2 = math.floor(low / 256) % 256
-  local b3 = math.floor(low / 65536) % 256
-  local b4 = math.floor(low / 16777216) % 256
-  local b5 = high % 256
-  local b6 = math.floor(high / 256) % 256
-  local b7 = math.floor(high / 65536) % 256
-  local b8 = math.floor(high / 16777216) % 256
-  return string.char(b1, b2, b3, b4, b5, b6, b7, b8)
+  return bit64_u64_to_le_bytes(bit64_from_number(value))
 end
 
 --- Decodes a fixed-length 8-byte sequence into a 64-bit integer.
@@ -229,18 +275,29 @@ end
 --- @return Int64HighLow value The decoded 64-bit value as {high_32, low_32}.
 --- @return integer new_pos The new position in the buffer after decoding.
 function pb.decode_fixed64(buffer, pos)
-  --- @type integer, integer, integer, integer, integer, integer, integer, integer
-  local b1, b2, b3, b4, b5, b6, b7, b8 = string.byte(buffer, pos, pos + 7)
-  local low = b1 + b2 * 256 + b3 * 65536 + b4 * 16777216
-  local high = b5 + b6 * 256 + b7 * 65536 + b8 * 16777216
-  return bit64_new(high, low), pos + 8
+  return bit64_le_bytes_to_u64(buffer, pos), pos + 8
 end
 
 --- Encodes a floating-point number into a 4-byte IEEE 754 single-precision format.
 --- @param value number The floating-point number to encode.
 --- @return string bytes The encoded 4-byte sequence.
 function pb.encode_float(value)
+  -- The frexp path below cannot represent these: it reads a non-finite as a
+  -- mantissa of 1 and an exponent of 0, so every one of them encoded as 0.5.
+  -- Emitted as the canonical patterns any conformant parser produces.
+  if value ~= value then
+    return string.char(0x00, 0x00, 0xC0, 0x7F)
+  elseif value == INF then
+    return string.char(0x00, 0x00, 0x80, 0x7F)
+  elseif value == -INF then
+    return string.char(0x00, 0x00, 0x80, 0xFF)
+  end
+
   if value == 0 then
+    -- -0.0 == 0, so the sign is only observable through the reciprocal.
+    if 1 / value < 0 then
+      return string.char(0x00, 0x00, 0x00, 0x80)
+    end
     return string.char(0, 0, 0, 0)
   end
 
@@ -250,27 +307,36 @@ function pb.encode_float(value)
     value = -value
   end
 
-  local mantissa, exponent = math_frexp(value)
-  exponent = exponent - 1
-  mantissa = mantissa * 2 - 1
-
-  local e = exponent + 127
-  if e < 0 then
+  local e, m
+  if value < FLOAT_MIN_NORMAL then
+    -- Subnormal: the mantissa is the whole value counted in units of the smallest
+    -- one, since there is no implicit leading bit to subtract off.
     e = 0
-    mantissa = 0
-  elseif e > 255 then
-    e = 255
-    mantissa = 0
+    m = round_half_even(math_ldexp(value, 149))
+  else
+    local mantissa, exponent = math_frexp(value)
+    e = exponent - 1 + 127
+    if e >= 255 then
+      -- 255 is the all-ones exponent, so it has to be reached by clamping too:
+      -- leaving it to a finite input would emit a nonzero mantissa, i.e. a NaN.
+      e = 255
+      m = 0
+    else
+      m = round_half_even((mantissa * 2 - 1) * 0x800000)
+    end
   end
 
-  local m = math.floor(mantissa * 0x800000 + 0.5)
+  -- Rounding to nearest can carry out of the mantissa. Bit 23 of m lands on the
+  -- exponent's low bit below, which is the wanted answer in both bands: a subnormal
+  -- carries into the smallest normal, a normal into the next binade, and the largest
+  -- finite into the all-ones exponent, i.e. infinity.
+  if m >= 0x800000 then
+    m = 0
+    e = e + 1
+  end
 
-  local b1 = m % 256
-  local b2 = math.floor(m / 256) % 256
-  local b3 = bit32_raw_bor(math.floor(m / 65536), bit32_raw_lshift(e % 2, 7))
-  local b4 = bit32_raw_bor(bit32_raw_rshift(e, 1), bit32_raw_lshift(sign, 7))
-
-  return string.char(b1, b2, b3, b4)
+  local word = bit32_raw_bor(bit32_raw_lshift(sign, 31), bit32_raw_lshift(e, 23))
+  return bit32_u32_to_le_bytes(bit32_raw_bor(word, m))
 end
 
 --- Decodes a 4-byte IEEE 754 single-precision format into a floating-point number.
@@ -279,17 +345,34 @@ end
 --- @return number value The decoded floating-point value.
 --- @return integer new_pos The new position in the buffer after decoding.
 function pb.decode_float(buffer, pos)
-  local b1, b2, b3, b4 = string.byte(buffer, pos, pos + 3)
+  local word = bit32_le_bytes_to_u32(buffer, pos)
 
-  local sign = bit32_raw_rshift(b4, 7)
-  local e = bit32_raw_lshift(bit32_raw_band(b4, 0x7F), 1) + bit32_raw_rshift(b3, 7)
-  local m = bit32_raw_band(b3, 0x7F) * 65536 + b2 * 256 + b1
+  local sign = bit32_raw_rshift(word, 31)
+  local e = bit32_raw_band(bit32_raw_rshift(word, 23), 0xFF)
+  local m = bit32_raw_band(word, 0x7FFFFF)
 
   if e == 0 and m == 0 then
-    return 0, pos + 4
+    return sign == 1 and NEG_ZERO or 0, pos + 4
   end
 
-  local result = math_ldexp(1 + m / 0x800000, e - 127)
+  -- IEEE 754 reserves an all-ones exponent for the non-finite values: infinity
+  -- when the mantissa is zero, NaN otherwise. Without this the mantissa term is
+  -- scaled by 2^128 and a NaN comes back as a plausible finite reading.
+  if e == 255 then
+    if m == 0 then
+      return sign == 1 and -INF or INF, pos + 4
+    end
+    return NAN, pos + 4
+  end
+
+  -- A subnormal carries no implicit leading one and sits at the minimum exponent
+  -- rather than at the bias.
+  local result
+  if e == 0 then
+    result = math_ldexp(m / 0x800000, -126)
+  else
+    result = math_ldexp(1 + m / 0x800000, e - 127)
+  end
   if sign == 1 then
     result = -result
   end
@@ -301,7 +384,19 @@ end
 --- @param value number The double-precision floating-point number to encode.
 --- @return string bytes The encoded 8-byte sequence.
 function pb.encode_double(value)
+  -- Non-finite, as in encode_float.
+  if value ~= value then
+    return string.char(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF8, 0x7F)
+  elseif value == INF then
+    return string.char(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x7F)
+  elseif value == -INF then
+    return string.char(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0xFF)
+  end
+
   if value == 0 then
+    if 1 / value < 0 then
+      return string.char(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80)
+    end
     return string.char(0, 0, 0, 0, 0, 0, 0, 0)
   end
 
@@ -311,34 +406,26 @@ function pb.encode_double(value)
     value = -value
   end
 
-  local mantissa, exponent = math_frexp(value)
-  exponent = exponent - 1
-  mantissa = mantissa * 2 - 1
-
-  local e = exponent + 1023
-  if e < 0 then
+  -- 52 bits of mantissa either way: 20 in high, 32 in low.
+  local e, m
+  if value < DOUBLE_MIN_NORMAL then
+    -- Subnormal, as in encode_float. No rounding: a double below this boundary is
+    -- already a whole multiple of the smallest subnormal, so the scale is exact.
     e = 0
-    mantissa = 0
-  elseif e > 2047 then
-    e = 2047
-    mantissa = 0
+    m = bit64_from_number(math_ldexp(value, 1074))
+  else
+    local mantissa, exponent = math_frexp(value)
+    e = exponent - 1 + 1023
+    if e > 2047 then
+      e = 2047
+      m = bit64_from_number(0)
+    else
+      m = bit64_from_number((mantissa * 2 - 1) * 0x10000000000000)
+    end
   end
-
-  -- Mantissa is 52 bits, split across bytes
-  local m = mantissa * 0x10000000000000 -- 2^52
-  local m_low = math.floor(m % 0x100000000)
-  local m_high = math.floor(m / 0x100000000) % 0x100000 -- 20 bits
-
-  local b1 = m_low % 256
-  local b2 = math.floor(m_low / 256) % 256
-  local b3 = math.floor(m_low / 65536) % 256
-  local b4 = math.floor(m_low / 16777216) % 256
-  local b5 = m_high % 256
-  local b6 = math.floor(m_high / 256) % 256
-  local b7 = bit32_raw_bor(math.floor(m_high / 65536), bit32_raw_lshift(e % 16, 4))
-  local b8 = bit32_raw_bor(bit32_raw_rshift(e, 4), bit32_raw_lshift(sign, 7))
-
-  return string.char(b1, b2, b3, b4, b5, b6, b7, b8)
+  local high = bit32_raw_bor(bit32_raw_lshift(sign, 31), bit32_raw_lshift(e, 20))
+  m[1] = bit32_raw_bor(high, bit32_raw_band(m[1], 0xFFFFF))
+  return bit64_u64_to_le_bytes(m)
 end
 
 --- Decodes an 8-byte IEEE 754 double-precision format into a floating-point number.
@@ -347,19 +434,34 @@ end
 --- @return number value The decoded double-precision floating-point value.
 --- @return integer new_pos The new position in the buffer after decoding.
 function pb.decode_double(buffer, pos)
-  local b1, b2, b3, b4, b5, b6, b7, b8 = string.byte(buffer, pos, pos + 7)
+  local word = bit64_le_bytes_to_u64(buffer, pos)
+  local high = word[1]
 
-  local sign = bit32_raw_rshift(b8, 7)
-  local e = bit32_raw_lshift(bit32_raw_band(b8, 0x7F), 4) + bit32_raw_rshift(b7, 4)
-  local m_high = bit32_raw_band(b7, 0x0F) * 65536 + b6 * 256 + b5
-  local m_low = b4 * 16777216 + b3 * 65536 + b2 * 256 + b1
-  local m = m_high * 0x100000000 + m_low
+  local sign = bit32_raw_rshift(high, 31)
+  local e = bit32_raw_band(bit32_raw_rshift(high, 20), 0x7FF)
+  word[1] = bit32_raw_band(high, 0xFFFFF)
+  local m = bit64_to_number(word)
 
   if e == 0 and m == 0 then
-    return 0, pos + 8
+    return sign == 1 and NEG_ZERO or 0, pos + 8
   end
 
-  local result = math_ldexp(1 + m / 0x10000000000000, e - 1023)
+  -- Non-finite, as in decode_float. Here the 2^1024 scale overflows to infinity
+  -- instead, so an unhandled NaN was indistinguishable from a real infinity.
+  if e == 2047 then
+    if m == 0 then
+      return sign == 1 and -INF or INF, pos + 8
+    end
+    return NAN, pos + 8
+  end
+
+  -- Subnormal, as in decode_float.
+  local result
+  if e == 0 then
+    result = math_ldexp(m / 0x10000000000000, -1022)
+  else
+    result = math_ldexp(1 + m / 0x10000000000000, e - 1023)
+  end
   if sign == 1 then
     result = -result
   end
@@ -384,12 +486,7 @@ end
 --- @param value integer The zigzag-encoded value.
 --- @return integer decoded The signed integer.
 function pb.zigzag_decode32(value)
-  local result = bit32_raw_bxor(bit32_raw_rshift(value, 1), -bit32_raw_band(value, 1))
-  -- Convert unsigned to signed if high bit is set
-  if result >= 0x80000000 then
-    result = result - 0x100000000
-  end
-  return result
+  return bit32_to_signed(bit32_raw_bxor(bit32_raw_rshift(value, 1), -bit32_raw_band(value, 1)))
 end
 
 --- Encodes a signed 64-bit integer using zigzag encoding.
@@ -457,14 +554,20 @@ local function decode_scalar(protoSchema, fieldType, wireType, buffer, pos)
       value = pb.zigzag_decode64(raw)
     elseif fieldType == protoSchema.DataType.SINT32 then
       local raw
-      raw, pos = pb.decode_varint(buffer, pos)
-      value = pb.zigzag_decode32(raw)
+      raw, pos = pb.decode_varint64(buffer, pos)
+      value = pb.zigzag_decode32(raw[2])
     elseif fieldType == protoSchema.DataType.BOOL then
       value, pos = pb.decode_varint(buffer, pos)
       value = value ~= 0 -- Convert to boolean
+    elseif fieldType == protoSchema.DataType.UINT32 then
+      local raw
+      raw, pos = pb.decode_varint64(buffer, pos)
+      value = raw[2]
     else
-      -- INT32, UINT32, ENUM, etc.
-      value, pos = pb.decode_varint(buffer, pos)
+      -- INT32, ENUM: truncated to the low word, so 0xFFFFFFFF reads as -1.
+      local raw
+      raw, pos = pb.decode_varint64(buffer, pos)
+      value = bit32_to_signed(raw[2])
     end
   elseif wireType == protoSchema.WireType.FIXED64 then
     if fieldType == protoSchema.DataType.DOUBLE then
@@ -476,8 +579,11 @@ local function decode_scalar(protoSchema, fieldType, wireType, buffer, pos)
   elseif wireType == protoSchema.WireType.FIXED32 then
     if fieldType == protoSchema.DataType.FLOAT then
       value, pos = pb.decode_float(buffer, pos)
+    elseif fieldType == protoSchema.DataType.SFIXED32 then
+      value, pos = pb.decode_fixed32(buffer, pos)
+      value = bit32_to_signed(value)
     else
-      -- FIXED32, SFIXED32
+      -- FIXED32
       value, pos = pb.decode_fixed32(buffer, pos)
     end
   else
@@ -537,6 +643,28 @@ local function default_value(protoSchema, field)
   return 0
 end
 
+local function ascending(a, b)
+  local ta, tb = type(a), type(b)
+  if ta ~= tb then
+    return ta < tb
+  elseif ta == "table" then
+    -- Unsigned high word, so negative 64-bit keys sort after positive ones: deterministic, not numeric.
+    return a[1] < b[1] or (a[1] == b[1] and a[2] < b[2])
+  elseif ta == "boolean" then
+    return b and not a
+  end
+  return a < b
+end
+
+local function sorted_keys(t)
+  local keys = {}
+  for key in pairs(t) do
+    keys[#keys + 1] = key
+  end
+  table.sort(keys, ascending)
+  return keys
+end
+
 --- Encodes a map field as the repeated key/value entry messages it is on the wire.
 --- @param protoSchema ProtoSchema The complete proto schema.
 --- @param field ProtoFieldSchema The map field's schema.
@@ -555,7 +683,8 @@ local function encode_map(protoSchema, field, field_number, entries)
   local key = bit32_to_unsigned(bit32_raw_lshift(field_number, 3)) + wire_type
 
   local buffer = ""
-  for entry_key, entry_value in pairs(entries) do
+  for _, entry_key in ipairs(sorted_keys(entries)) do
+    local entry_value = entries[entry_key]
     local entry = pb.encode(protoSchema, entrySchema, {
       [keyField.name] = entry_key,
       [valueField.name] = entry_value,
@@ -573,7 +702,8 @@ end
 function pb.encode(protoSchema, messageSchema, message)
   local buffer = ""
 
-  for field_number, field in pairs(messageSchema.fields) do
+  for _, field_number in ipairs(sorted_keys(messageSchema.fields)) do
+    local field = messageSchema.fields[field_number]
     local values = message[field.name]
     if values ~= nil and field.map then
       buffer = buffer .. encode_map(protoSchema, field, field_number, values)
@@ -832,11 +962,19 @@ function pb.selftest()
     end
   end
 
-  local function assert_bytes(actual, expected_hex, msg)
-    local expected = ""
-    for byte in expected_hex:gmatch("%x%x") do
-      expected = expected .. string.char(tonumber(byte, 16) or 0)
+  local function from_hex(hex)
+    local bytes = ""
+    for byte in hex:gmatch("%x%x") do
+      bytes = bytes .. string.char(tonumber(byte, 16) or 0)
     end
+    -- gmatch skips anything that is not a hex pair, so a typo silently yields a
+    -- short buffer, which the decoders then read past the end of.
+    assert(#bytes * 2 == #hex, "malformed hex literal: " .. hex)
+    return bytes
+  end
+
+  local function assert_bytes(actual, expected_hex, msg)
+    local expected = from_hex(expected_hex)
     if actual == expected then
       passed = passed + 1
       print("  PASS: " .. msg)
@@ -853,6 +991,16 @@ function pb.selftest()
     else
       failed = failed + 1
       print("  FAIL: " .. msg .. ": expected " .. tostring(expected) .. ", got " .. tostring(actual))
+    end
+  end
+
+  local function assert_nan(actual, msg)
+    if type(actual) == "number" and actual ~= actual then
+      passed = passed + 1
+      print("  PASS: " .. msg)
+    else
+      failed = failed + 1
+      print("  FAIL: " .. msg .. ": expected NaN, got " .. tostring(actual))
     end
   end
 
@@ -1033,6 +1181,59 @@ function pb.selftest()
     assert_close(dec, v, 1e-4, "float roundtrip " .. v)
   end
 
+  assert_bytes(pb.encode_float(NAN), "0000C07F", "float encode NaN")
+  assert_bytes(pb.encode_float(math.huge), "0000807F", "float encode +infinity")
+  assert_bytes(pb.encode_float(-math.huge), "000080FF", "float encode -infinity")
+
+  -- Decoded from the canonical wire patterns rather than from this encoder's own
+  -- output, so the assertions still hold if both sides break together. The
+  -- signalling and non-canonical mantissas are the ones a real producer varies.
+  assert_nan(pb.decode_float(from_hex("0000C07F"), 1), "float decode quiet NaN")
+  assert_nan(pb.decode_float(from_hex("0100807F"), 1), "float decode signalling NaN")
+  assert_nan(pb.decode_float(from_hex("FFFFFFFF"), 1), "float decode negative NaN")
+  assert_eq(pb.decode_float(from_hex("0000807F"), 1), math.huge, "float decode +infinity")
+  assert_eq(pb.decode_float(from_hex("000080FF"), 1), -math.huge, "float decode -infinity")
+
+  -- The largest finite float still decodes finite: the guard keys on the
+  -- all-ones exponent, not on magnitude.
+  assert_close(pb.decode_float(from_hex("FFFF7F7F"), 1), 3.4028234663853e38, 1e30, "float decode max finite")
+
+  -- A finite double too large for a float saturates to infinity. Expectations
+  -- come from a C (float) cast, not from this encoder.
+  assert_bytes(pb.encode_float(3.5e38), "0000807F", "float encode just over max to +infinity")
+  assert_bytes(pb.encode_float(-3.5e38), "000080FF", "float encode just under min to -infinity")
+  assert_bytes(pb.encode_float(1e39), "0000807F", "float encode far over max to +infinity")
+  -- Below the midpoint to 2^128 it rounds down to the largest finite float
+  -- instead, so the saturation above is not simply "big magnitude wins".
+  assert_bytes(pb.encode_float(3.40282349e38), "FFFF7F7F", "float encode under midpoint to max finite")
+
+  -- Mantissa rounding that carries into the exponent. The odd-exponent cases are
+  -- the ones where the carry bit collides with the exponent's low bit.
+  assert_bytes(pb.encode_float(2 - 2 ^ -25), "00000040", "float encode carry into odd exponent")
+  assert_bytes(pb.encode_float(32 * (1 - 2 ^ -25)), "00000042", "float encode carry into odd exponent, larger")
+  assert_bytes(pb.encode_float(4 - 2 ^ -24), "00008040", "float encode carry into even exponent")
+
+  -- Subnormals, where there is no implicit leading one and the exponent is pinned.
+  -- Expectations from a C (float) cast; test/float_vectors_test.lua sweeps the band.
+  assert_bytes(pb.encode_float(2 ^ -149), "01000000", "float encode smallest subnormal")
+  assert_bytes(pb.encode_float(2 ^ -126 - 2 ^ -149), "FFFF7F00", "float encode largest subnormal")
+  assert_eq(pb.decode_float(from_hex("01000000"), 1), 2 ^ -149, "float decode smallest subnormal")
+  assert_eq(pb.decode_float(from_hex("FFFF7F00"), 1), 2 ^ -126 - 2 ^ -149, "float decode largest subnormal")
+
+  -- Exact midpoints, which IEEE 754 breaks toward the even mantissa rather than
+  -- away from zero. Half of these go to the wrong neighbour under floor(x + 0.5).
+  assert_bytes(pb.encode_float(2 ^ -150), "00000000", "float encode subnormal tie down to zero")
+  assert_bytes(pb.encode_float(3 * 2 ^ -150), "02000000", "float encode subnormal tie up")
+  assert_bytes(pb.encode_float((2 ^ 24 - 1) * 2 ^ -150), "00008000", "float encode tie carrying to normal")
+  assert_bytes(pb.encode_float(1 + 2 ^ -24), "0000803F", "float encode normal tie down")
+  assert_bytes(pb.encode_float(1 + 3 * 2 ^ -24), "0200803F", "float encode normal tie up")
+
+  assert_bytes(pb.encode_float(NEG_ZERO), "00000080", "float encode negative zero")
+  assert_bytes(pb.encode_float(0), "00000000", "float encode positive zero")
+  local neg_zero_f = pb.decode_float(from_hex("00000080"), 1)
+  assert_eq(1 / neg_zero_f, -INF, "float decode negative zero")
+  assert_eq(1 / pb.decode_float(from_hex("00000000"), 1), INF, "float decode positive zero")
+
   -- ============================================================================
   -- DOUBLE ENCODING
   -- ============================================================================
@@ -1044,6 +1245,33 @@ function pb.selftest()
     local dec = pb.decode_double(pb.encode_double(v), 1)
     assert_close(dec, v, 1e-10, "double roundtrip " .. v)
   end
+
+  assert_bytes(pb.encode_double(NAN), "000000000000F87F", "double encode NaN")
+  assert_bytes(pb.encode_double(math.huge), "000000000000F07F", "double encode +infinity")
+  assert_bytes(pb.encode_double(-math.huge), "000000000000F0FF", "double encode -infinity")
+
+  assert_nan(pb.decode_double(from_hex("000000000000F87F"), 1), "double decode quiet NaN")
+  assert_nan(pb.decode_double(from_hex("010000000000F07F"), 1), "double decode signalling NaN")
+  assert_nan(pb.decode_double(from_hex("FFFFFFFFFFFFFFFF"), 1), "double decode negative NaN")
+  assert_eq(pb.decode_double(from_hex("000000000000F07F"), 1), math.huge, "double decode +infinity")
+  assert_eq(pb.decode_double(from_hex("000000000000F0FF"), 1), -math.huge, "double decode -infinity")
+
+  -- Subnormals, as in the float section. math_ldexp rather than 2 ^ -1074: LuaJIT 2.0
+  -- returns zero for a power of two below the normal range, and it is in the matrix.
+  local smallest_double = math_ldexp(1.0, -1074)
+  local largest_subnormal_double = math_ldexp(2 ^ 52 - 1, -1074)
+  assert_bytes(pb.encode_double(smallest_double), "0100000000000000", "double encode smallest subnormal")
+  assert_bytes(pb.encode_double(largest_subnormal_double), "FFFFFFFFFFFF0F00", "double encode largest subnormal")
+  assert_eq(pb.decode_double(from_hex("0100000000000000"), 1), smallest_double, "double decode smallest subnormal")
+  assert_eq(
+    pb.decode_double(from_hex("FFFFFFFFFFFF0F00"), 1),
+    largest_subnormal_double,
+    "double decode largest subnormal"
+  )
+
+  assert_bytes(pb.encode_double(NEG_ZERO), "0000000000000080", "double encode negative zero")
+  assert_eq(1 / pb.decode_double(from_hex("0000000000000080"), 1), -INF, "double decode negative zero")
+  assert_eq(1 / pb.decode_double(from_hex("0000000000000000"), 1), INF, "double decode positive zero")
 
   -- ============================================================================
   -- ZIGZAG ENCODING (official protobuf spec test vectors)
@@ -1058,11 +1286,7 @@ function pb.selftest()
     { -2147483648, 4294967295 },
   }
   for _, t in ipairs(zigzag32_vectors) do
-    local enc = pb.zigzag_encode32(t[1])
-    if enc < 0 then
-      enc = enc + 0x100000000
-    end
-    assert_eq(enc, t[2], "zigzag32 encode " .. t[1])
+    assert_eq(pb.zigzag_encode32(t[1]), t[2], "zigzag32 encode " .. t[1])
   end
 
   for _, v in ipairs({ 0, 1, -1, 100, -100, 2147483647, -2147483648 }) do
@@ -1198,6 +1422,29 @@ function pb.selftest()
     local dec = pb.decode(Schema, doubleSchema, pb.encode(Schema, doubleSchema, { value = v }))
     assert_close(dec.value, v, 1e-10, "encode/decode double " .. v)
   end
+
+  -- The reported failure came through the FIXED32/FLOAT and FIXED64/DOUBLE
+  -- branches of encode_scalar and decode_scalar, not through the codecs alone,
+  -- so a wrong-width or wrong-branch regression there would leave the direct
+  -- codec assertions above green.
+  assert_nan(
+    pb.decode(Schema, floatSchema, pb.encode(Schema, floatSchema, { value = NAN })).value,
+    "encode/decode float NaN"
+  )
+  assert_nan(
+    pb.decode(Schema, doubleSchema, pb.encode(Schema, doubleSchema, { value = NAN })).value,
+    "encode/decode double NaN"
+  )
+  assert_eq(
+    pb.decode(Schema, floatSchema, pb.encode(Schema, floatSchema, { value = INF })).value,
+    INF,
+    "encode/decode float +infinity"
+  )
+  assert_eq(
+    pb.decode(Schema, doubleSchema, pb.encode(Schema, doubleSchema, { value = -INF })).value,
+    -INF,
+    "encode/decode double -infinity"
+  )
 
   -- Fixed32
   local fixed32FieldSchema = make_schema("Fixed32", "value", Schema.DataType.FIXED32, Schema.WireType.FIXED32)
@@ -1635,5 +1882,11 @@ function pb.selftest()
   print(string.format("\nProtobuf operations: %d/%d tests passed\n", passed, passed + failed))
   return failed == 0
 end
+
+-- Whichever frexp/ldexp the module bound at load. Exposed so the fallbacks can
+-- be compared against a native implementation directly; the codecs only reach
+-- them over the argument range the wire format produces, which is narrower than
+-- the range the fallbacks have to be correct over.
+pb._math = { frexp = math_frexp, ldexp = math_ldexp }
 
 return pb


### PR DESCRIPTION
`copier update` to control4-driver-template `v0.9.23`; the update's diff is exactly the template's own v0.9.22..v0.9.23 plus `.copier-answers.yml`, no local drift, no conflict markers.

What arrives, in the order it matters to this driver:

- **#58 — the five amalgams re-vendored** from their release assets (verified byte-identical to local builds of the tags; each asset + the template's stylua flags reproduces the committed file):

  | amalgam | now | was |
  |---|---|---|
  | `bitn.lua` | v0.6.4 | v0.6.3 |
  | `crypto.lua` | v0.2.4 | v0.2.2 |
  | `noiseprotocol.lua` | v0.6.6 | v0.6.4 |
  | `bthome.lua` | v0.1.7 | v0.1.5 |
  | `protobuf.lua` | v0.6.9 | v0.6.7 |

  protobuf v0.6.9 is the one that changes wire behaviour here: NaN/infinity decode correctly instead of as ~5.1e38 (FL-15), subnormals and round-half-to-even in the float codecs (FL-16), `sfixed32` sign (FL-18), negative `int32`/`enum` on LuaJIT (FL-19), stable field and map order. bitn v0.6.4 binds `string.pack` only after probing for the 5.3 dialect, which is what makes the other four safe on a controller (its lpack raised on the previous helpers; FL-20). crypto/noiseprotocol/bthome route byte packing through bitn with unchanged output.
- **#54 — first-party NaN handling** (`tofinite`, JSON sentinels in `SerializeSafe`, NaN-aware `Values:update`). Load-bearing here: ESPHome sends NaN for any float a device has not reported yet, and with a correct decoder that now reaches `Values:update`, where `existing.value ~= value` was true on every push for a NaN and rewrote persistent storage each time (measured 5 writes vs 1 on the bot's review of #58). With #54 it is 1.
- **#57 — `SensorValueParams` / `CelsiusFromParams`** (DRV-121). Not called here yet; the call sites are the per-repo half of that ticket.
- **#59** — comment correction.

Verified locally: `make check`, `make test` 517 passed / 0 failed (up from 438: the two new template suites), and every amalgam's `selftest()` on LuaJIT under this repo's `test/c4_shim.lua` (the controller's lpack-shaped `string.pack`), all passing. On the dev controller the bot ran every amalgam's selftest one driver at a time at this exact vendor set and timed a Noise handshake (~300 ms, 16% of LuaJIT's mcode budget, no degradation over 110 handshakes); those results are on control4-driver-template#58.