### PR TITLE
chore: update to template v0.9.24

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.9.23
+_commit: v0.9.24
 _src_path: git@github.com:finitelabs/control4-driver-template.git
 distributions: drivercentral oss
 github_org: finitelabs

--- a/src/lib/utils.lua
+++ b/src/lib/utils.lua
@@ -1086,7 +1086,13 @@ function CelsiusFromParams(tParams, defaultScale)
   if value == nil then
     return nil
   end
-  return ToCelsius(value, Select(tParams, "SCALE") or defaultScale)
+  -- Select yields the empty string, not nil, for a SCALE key sent blank, and ""
+  -- is truthy; `or` alone would read VALUE in a scale that names nothing.
+  local scale = Select(tParams, "SCALE")
+  if IsEmpty(scale) then
+    scale = defaultScale
+  end
+  return ToCelsius(value, scale)
 end
 
 --------------------------------------------------------------------------------

--- a/test/test_sensor_params.lua
+++ b/test/test_sensor_params.lua
@@ -107,6 +107,14 @@ do
   T.eq("a setpoint handler reads Fahrenheit", CelsiusFromParams({ VALUE = 70.7 }, "F"), 21.5)
 end
 
+do
+  -- Select returns the empty string for SCALE = "" rather than nil, and "" is
+  -- truthy, so an absent-SCALE fallback has to treat it as absent explicitly.
+  T.eq("an empty SCALE falls back like an absent one", CelsiusFromParams({ VALUE = 21.5, SCALE = "" }, "CELSIUS"), 21.5)
+  T.eq("an empty SCALE on a Fahrenheit default", CelsiusFromParams({ VALUE = 70.7, SCALE = "" }, "F"), 21.5)
+  T.eq("an empty SCALE still yields nil with no VALUE", CelsiusFromParams({ SCALE = "" }, "CELSIUS"), nil)
+end
+
 --------------------------------------------------------------------------------
 T.section("Params arriving as strings still parse")
 --------------------------------------------------------------------------------


### PR DESCRIPTION
`copier update` from template `v0.9.23` to `v0.9.24`, a single fix.

**control4-driver-template#60 (DRV-123)** — `CelsiusFromParams` treated an empty `SCALE` as a scale rather than as absent. `Select` returns `""` for a key sent blank, and `""` is truthy in Lua, so the `or defaultScale` fallback never fired: `TemperatureScaleLetter("")` is nil, `ToCelsius` returns nil, and the reading was dropped. The code this helper replaced — a bare `tonumber(Select(tParams, "VALUE"))` — accepted that payload, so this restores prior behaviour rather than introducing a new assumption. An absent `SCALE` was always handled correctly; only the empty string was affected.

Guarded with `IsEmpty`, matching how the rest of `src/lib` tests a maybe-blank string. Three assertions added to `test/test_sensor_params.lua`; two were demonstrated red against the unfixed helper, and the third passes in both directions on purpose, pinning that the guard does not turn a `SCALE`-only payload into a number.

The emitter side (`SensorValueParams` with an empty scale) was checked across all eleven consumer repos and is unreachable — every call site passes a string literal or `getTemperatureScale()`, which falls back to `FAHRENHEIT` for a blank project property.

No provider is known to send `SCALE = ""`; this is defensive, and cut on its own rather than batched per Derek's call. `make check` and `make test` pass locally on the updated tree.
